### PR TITLE
move touch event from viewcontroller to view

### DIFF
--- a/ios/GiderosiOSPlayer/GiderosiOSPlayer/EAGLView.m
+++ b/ios/GiderosiOSPlayer/GiderosiOSPlayer/EAGLView.m
@@ -8,6 +8,8 @@
 
 #import "EAGLView.h"
 
+#include "giderosapi.h"
+
 @interface EAGLView (PrivateMethods)
 - (void)createFramebuffer;
 - (void)deleteFramebuffer;
@@ -168,6 +170,23 @@
 	
     // The framebuffer will be re-created (with the new resolution) at the beginning of the next setFramebuffer method call.
 	[self deleteFramebuffer];
+}
+
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    gdr_touchesBegan(touches, [event allTouches]);
+}
+- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    gdr_touchesMoved(touches, [event allTouches]);
+}
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    gdr_touchesEnded(touches, [event allTouches]);
+}
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    gdr_touchesCancelled(touches, [event allTouches]);
 }
 
 @end

--- a/ios/GiderosiOSPlayer/GiderosiOSPlayer/ViewController.m
+++ b/ios/GiderosiOSPlayer/GiderosiOSPlayer/ViewController.m
@@ -156,23 +156,6 @@
 	gdr_didReceiveMemoryWarning();
 }
 
-- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
-{
-	gdr_touchesBegan(touches, [event allTouches]);
-}
-- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
-{
-	gdr_touchesMoved(touches, [event allTouches]);
-}
-- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
-{
-	gdr_touchesEnded(touches, [event allTouches]);
-}
-- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
-{
-	gdr_touchesCancelled(touches, [event allTouches]);
-}
-
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
 	return gdr_shouldAutorotateToInterfaceOrientation(interfaceOrientation);


### PR DESCRIPTION
Handle touch event in view controller will cause the event fired twice if the subview also handles the touch event.
eg: iAd