### PR TITLE
3D Stuff corrections

### DIFF
--- a/2dsg/ogl.cpp
+++ b/2dsg/ogl.cpp
@@ -65,7 +65,9 @@ varying mediump vec4 fInColor;\
 void main() {\
  mediump vec4 col=mix(fColor,fInColor,fColorSel);\
  mediump vec4 tex=mix(vec4(1,1,1,1),texture2D(fTexture, fTexCoord),fTextureSel);\
- gl_FragColor = tex * col;\
+ mediump vec4 frag=tex *col;\
+ if (frag.a==0) discard;\
+ gl_FragColor = frag;\
 }";
 #else
 /* Vertex shader*/
@@ -107,7 +109,9 @@ const char *colorFShaderCode=
 "void main() {\n"
 " vec4 col=mix(fColor,fInColor,fColorSel);\n"
 " vec4 tex=mix(vec4(1.0f,1.0f,1.0f,1.0f),texture2D(fTexture, fTexCoord),fTextureSel);\n"
-" gl_FragColor = tex * col;\n"
+" vec4 frag=tex *col;\n"
+" if (frag.a==0) discard;\n"
+" gl_FragColor = frag;\n"
 "}\n";
 #endif
 

--- a/2dsg/sprite.h
+++ b/2dsg/sprite.h
@@ -227,7 +227,7 @@ public:
 
 	float z() const
 	{
-        return localTransform_.y();
+        return localTransform_.z();
 	}
 
 	float refX() const


### PR DESCRIPTION
Shaders: Do not process pixels with alpha=0, to correct pure transparency problem (tkhnoman issue)
Sprite: Correct Z coordinate retrieval which was incorrectly return Y