### PR TITLE
Canvas Scaling fix

### DIFF
--- a/desktop/headers/mainwindow.h
+++ b/desktop/headers/mainwindow.h
@@ -44,6 +44,7 @@ class MainWindow : public QMainWindow{
         bool fixedSize_;
         int width_;
         int height_;
+        float resolution_;
 
         Ui::MainWindowClass ui;
 

--- a/desktop/sources/mainwindow.cpp
+++ b/desktop/sources/mainwindow.cpp
@@ -54,8 +54,7 @@ void MainWindow::setFixedSize(bool fixedSize){
 
 void MainWindow::resizeWindow(int width, int height){
     if (resolution_ == 0){
-        const float widthf = width;
-        resolution_ = widthf / height;
+        resolution_ = (float)width / height;
     }
     if(ui.glCanvas->getHardwareOrientation() == eLandscapeLeft || ui.glCanvas->getHardwareOrientation() == eLandscapeRight){
         int temp = width;
@@ -97,8 +96,7 @@ void MainWindow::updateResolution(){
         height = ui.centralWidget->width();
     }
 
-    const float widthf = width;
-    const float resolution = widthf / height;
+    const float resolution = (float)width / height;
 
     if (resolution > resolution_){
        width = height * resolution_;

--- a/desktop/sources/mainwindow.cpp
+++ b/desktop/sources/mainwindow.cpp
@@ -25,6 +25,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     setScale(100);
     ui.setupUi(this);
 
+    resolution_ = 0;
     /*#if defined(Q_OS_MAC)
         setWindowFlags((windowFlags() | Qt::CustomizeWindowHint) & ~Qt::WindowMaximizeButtonHint);
     #else
@@ -52,6 +53,10 @@ void MainWindow::setFixedSize(bool fixedSize){
 }
 
 void MainWindow::resizeWindow(int width, int height){
+    if (resolution_ == 0){
+        const float widthf = width;
+        resolution_ = widthf / height;
+    }
     if(ui.glCanvas->getHardwareOrientation() == eLandscapeLeft || ui.glCanvas->getHardwareOrientation() == eLandscapeRight){
         int temp = width;
         width = height;
@@ -75,7 +80,11 @@ void MainWindow::fullScreenWindow(bool fullScreen){
     }
     else{
         this->showNormal();
-        setMaximumSize(width_, height_);
+        if(fixedSize_){
+            setMaximumSize(width_, height_);
+        }else{
+            setMaximumSize(16777215, 16777215);
+        }
     }
     updateResolution();
 }
@@ -88,6 +97,15 @@ void MainWindow::updateResolution(){
         height = ui.centralWidget->width();
     }
 
+    const float widthf = width;
+    const float resolution = widthf / height;
+
+    if (resolution > resolution_){
+       width = height * resolution_;
+    }else{
+       height = width / resolution_;
+    }
+    
     float canvasScaleFactor = 1;
     float widgetScaleFactor = 1;
     if (deviceScale() != 0) {


### PR DESCRIPTION
Canvas now scaled with 'Touch Window from Inside'

I'm new at Qt, so probably there are some weird things written.

(I still don't know how to save the resolution upon exit. Also, this code probably would be buggy if loaded from save data i think, since it detect first window size as aspect ratio)