### PR TITLE
Update dpad on controller for Android TV

### DIFF
--- a/plugins/controller/source/Android/src/com/giderosmobile/android/plugins/controller/GControllerDefault.java
+++ b/plugins/controller/source/Android/src/com/giderosmobile/android/plugins/controller/GControllerDefault.java
@@ -196,7 +196,11 @@ public class GControllerDefault implements GControllerInterface {
 				else
 				{
 					controller.handleLeftTrigger(event.getAxisValue(MotionEvent.AXIS_LTRIGGER));
-        	    	controller.handleRightTrigger(event.getAxisValue(MotionEvent.AXIS_RTRIGGER));
+        	    			controller.handleRightTrigger(event.getAxisValue(MotionEvent.AXIS_RTRIGGER));
+					controller.handleDPadUpButton(event.getAxisValue(MotionEvent.AXIS_HAT_Y));
+					controller.handleDPadDownButton(event.getAxisValue(MotionEvent.AXIS_HAT_Y));
+					controller.handleDPadLeftButton(event.getAxisValue(MotionEvent.AXIS_HAT_X));
+					controller.handleDPadRightButton(event.getAxisValue(MotionEvent.AXIS_HAT_X));
 				}
 			}
 			return true;


### PR DESCRIPTION
DPad controller did not work on Android TV using official gamepad -
fixed!