### PR TITLE
Theme support for Gideros Studio and HTML output.

### DIFF
--- a/ui/Resources Embedded/defaultTheme.ini
+++ b/ui/Resources Embedded/defaultTheme.ini
@@ -1,0 +1,413 @@
+[General]
+FontFamily=Consolas
+FontSize=12
+CaretForegroundColor=16777115
+CaretLineBackgroundColor=1776926
+MatchedBraceForegroundColor=16777215
+MatchedBraceBackgroundColor=4473924
+UnmatchedBraceForegroundColor=2566178
+UnmatchedBraceBackgroundColor=12303291
+MarkerForegroundColor=2566178
+MarkerBackgroundColor=5348047
+FoldMarginFirstColor=0
+FoldMarginSecondColor=8421504
+IndentationGuidesForegroundColor=16777215
+IndentationGuidesBackgroundColor=0
+IndicatorForegroundColor=128
+IndicatorOutlineColor=240
+MarginsForegroundColor=16777215
+MarginsBackgroundColor=2566178
+[Scintilla]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;color  = text color -> [0..16777215]           ;;
+;;eolfil = end-of-line fill -> true | false      ;;
+;;font   = family, size, bold, italic, underline ;;
+;;font2  = family, size, bold, italic, underline ;;
+;;paper  = background color -> [0..16777215]     ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;Default
+Lua\style0\color=16777215
+Lua\style0\eolfill=false
+Lua\style0\font=Consolas, 12, 0, 0, 0
+Lua\style0\font2=Consolas, 12, 0, 0, 0
+Lua\style0\paper=2566178
+;Comment
+Lua\style1\color=8421504
+Lua\style1\eolfill=true
+Lua\style1\font=Consolas, 12, 0, 0, 0
+Lua\style1\font2=Consolas, 12, 0, 0, 0
+Lua\style1\paper=2566178
+;LineComment
+Lua\style2\color=8421504
+Lua\style2\eolfill=false
+Lua\style2\font=Consolas, 12, 0, 0, 0
+Lua\style2\font2=Consolas, 12, 0, 0, 0
+Lua\style2\paper=2566178
+;Number
+Lua\style4\color=11436543
+Lua\style4\eolfill=false
+Lua\style4\font=Consolas, 12, 0, 0, 0
+Lua\style4\font2=Consolas, 12, 0, 0, 0
+Lua\style4\paper=2566178
+;Keyword
+Lua\style5\color=16328306
+Lua\style5\eolfill=false
+Lua\style5\font=Consolas, 12, 0, 0, 0
+Lua\style5\font2=Consolas, 12, 0, 0, 0
+Lua\style5\paper=2566178
+;String
+Lua\style6\color=15129460
+Lua\style6\eolfill=false
+Lua\style6\font=Consolas, 12, 0, 0, 0
+Lua\style6\font2=Consolas, 12, 0, 0, 0
+Lua\style6\paper=2566178
+;Character
+Lua\style7\color=8421504
+Lua\style7\eolfill=false
+Lua\style7\font=Consolas, 12, 0, 0, 0
+Lua\style7\font2=Consolas, 12, 0, 0, 0
+Lua\style7\paper=2566178
+;LiteralString
+Lua\style8\color=15129460
+Lua\style8\eolfill=false
+Lua\style8\font=Consolas, 12, 0, 0, 0
+Lua\style8\font2=Consolas, 12, 0, 0, 0
+Lua\style8\paper=2566178
+;Preprocessor
+Lua\style9\color=8355584
+Lua\style9\eolfill=false
+Lua\style9\font=Consolas, 12, 0, 0, 0
+Lua\style9\font2=Consolas, 12, 0, 0, 0
+Lua\style9\paper=2566178
+;Operator
+Lua\style10\color=15790320
+Lua\style10\eolfill=false
+Lua\style10\font=Consolas, 12, 0, 0, 0
+Lua\style10\font2=Consolas, 12, 0, 0, 0
+Lua\style10\paper=2566178
+;Identifier
+Lua\style11\color=15790320
+Lua\style11\eolfill=false
+Lua\style11\font=Consolas, 12, 0, 0, 0
+Lua\style11\font2=Consolas, 12, 0, 0, 0
+Lua\style11\paper=2566178
+;UnclosedString
+Lua\style12\color=15129460
+Lua\style12\eolfill=true
+Lua\style12\font=Consolas, 12, 0, 0, 1
+Lua\style12\font2=Consolas, 12, 0, 0, 1
+Lua\style12\paper=2566178
+;BasicFunctions
+Lua\style13\color=5348047
+Lua\style13\eolfill=false
+Lua\style13\font=Consolas, 12, 0, 0, 0
+Lua\style13\font2=Consolas, 12, 0, 0, 0
+Lua\style13\paper=2566178;StringTableMathsFunctions
+Lua\style14\color=5348047
+Lua\style14\eolfill=false
+Lua\style14\font=Consolas, 12, 0, 0, 0
+Lua\style14\font2=Consolas, 12, 0, 0, 0
+Lua\style14\paper=2566178;CoroutinesIOSystemFacilities
+Lua\style15\color=5348047
+Lua\style15\eolfill=false
+Lua\style15\font=Consolas, 12, 0, 0, 0
+Lua\style15\font2=Consolas, 12, 0, 0, 0
+Lua\style15\paper=2566178;KeywordSet5
+Lua\style16\color=0
+Lua\style16\eolfill=false
+Lua\style16\font=Consolas, 12, 0, 0, 0
+Lua\style16\font2=Consolas, 12, 0, 0, 0
+Lua\style16\paper=2566178;KeywordSet6
+Lua\style17\color=0
+Lua\style17\eolfill=false
+Lua\style17\font=Consolas, 12, 0, 0, 0
+Lua\style17\font2=Consolas, 12, 0, 0, 0
+Lua\style17\paper=2566178;KeywordSet7
+Lua\style18\color=0
+Lua\style18\eolfill=false
+Lua\style18\font=Consolas, 12, 0, 0, 0
+Lua\style18\font2=Consolas, 12, 0, 0, 0
+Lua\style18\paper=2566178;KeywordSet8
+Lua\style19\color=0
+Lua\style19\eolfill=false
+Lua\style19\font=Consolas, 12, 0, 0, 0
+Lua\style19\font2=Consolas, 12, 0, 0, 0
+Lua\style19\paper=2566178;Label
+Lua\style20\color=8355584
+Lua\style20\eolfill=false
+Lua\style20\font=Consolas, 12, 0, 0, 0
+Lua\style20\font2=Consolas, 12, 0, 0, 0
+Lua\style20\paper=2566178;
+Lua\properties\foldcompact=true;
+Lua\defaultcolor=16777215
+Lua\defaultpaper=2566178
+Lua\defaultfont=Consolas, 12, 0, 0, 0
+Lua\defaultfont2=Consolas, 12, 0, 0, 0
+Lua\autoindentstyle=-1
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;Default
+C%2B%2B\style0\color=16777215
+C%2B%2B\style0\eolfill=false
+C%2B%2B\style0\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style0\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style0\paper=2566178;Comment
+C%2B%2B\style1\color=8421504
+C%2B%2B\style1\eolfill=false
+C%2B%2B\style1\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style1\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style1\paper=2566178;CommentLine
+C%2B%2B\style2\color=8421504
+C%2B%2B\style2\eolfill=false
+C%2B%2B\style2\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style2\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style2\paper=2566178;CommentDoc
+C%2B%2B\style3\color= 2514175
+C%2B%2B\style3\eolfill=false
+C%2B%2B\style3\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style3\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style3\paper=2566178;Number
+C%2B%2B\style4\color=11436543
+C%2B%2B\style4\eolfill=false
+C%2B%2B\style4\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style4\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style4\paper=2566178;Keyword
+C%2B%2B\style5\color=16328306
+C%2B%2B\style5\eolfill=false
+C%2B%2B\style5\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style5\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style5\paper=2566178;DoubleQuotedString
+C%2B%2B\style6\color=15129460
+C%2B%2B\style6\eolfill=false
+C%2B%2B\style6\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style6\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style6\paper=2566178;SingleQuotedString
+C%2B%2B\style7\color=15129460
+C%2B%2B\style7\eolfill=false
+C%2B%2B\style7\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style7\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style7\paper=2566178;UUID
+C%2B%2B\style8\color=15388106
+C%2B%2B\style8\eolfill=false
+C%2B%2B\style8\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style8\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style8\paper=2566178;PreProcessor
+C%2B%2B\style9\color=8355584
+C%2B%2B\style9\eolfill=false
+C%2B%2B\style9\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style9\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style9\paper=2566178;Operator
+C%2B%2B\style10\color=15790320
+C%2B%2B\style10\eolfill=false
+C%2B%2B\style10\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style10\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style10\paper=2566178;Identifier
+C%2B%2B\style11\color=15790320
+C%2B%2B\style11\eolfill=false
+C%2B%2B\style11\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style11\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style11\paper=2566178;UnclosedString
+C%2B%2B\style12\color=15129460
+C%2B%2B\style12\eolfill=true
+C%2B%2B\style12\font=Consolas, 12, 0, 0, 1
+C%2B%2B\style12\font2=Consolas, 12, 0, 0, 1
+C%2B%2B\style12\paper=14729440;VerbatimString
+C%2B%2B\style13\color=15129460
+C%2B%2B\style13\eolfill=true
+C%2B%2B\style13\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style13\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style13\paper=14745568;Regex
+C%2B%2B\style14\color=15129460
+C%2B%2B\style14\eolfill=true
+C%2B%2B\style14\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style14\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style14\paper=14741728;CommentLineDoc
+C%2B%2B\style15\color=4157503
+C%2B%2B\style15\eolfill=false
+C%2B%2B\style15\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style15\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style15\paper=2566178;KeywordSet2
+C%2B%2B\style16\color=5348047
+C%2B%2B\style16\eolfill=false
+C%2B%2B\style16\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style16\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style16\paper=2566178;CommentDocKeyword
+C%2B%2B\style17\color=3170464
+C%2B%2B\style17\eolfill=false
+C%2B%2B\style17\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style17\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style17\paper=2566178;CommentDocKeywordError
+C%2B%2B\style18\color=8405024
+C%2B%2B\style18\eolfill=false
+C%2B%2B\style18\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style18\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style18\paper=2566178;GlobalClass
+C%2B%2B\style19\color=16777215
+C%2B%2B\style19\eolfill=false
+C%2B%2B\style19\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style19\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style19\paper=2566178;RawString
+C%2B%2B\style20\color=15129460
+C%2B%2B\style20\eolfill=false
+C%2B%2B\style20\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style20\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style20\paper=16774143;TripleQuotedVerbatimString
+C%2B%2B\style21\color=15129460
+C%2B%2B\style21\eolfill=true
+C%2B%2B\style21\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style21\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style21\paper=14745568;HashQuotedString
+C%2B%2B\style22\color=15129460
+C%2B%2B\style22\eolfill=true
+C%2B%2B\style22\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style22\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style22\paper=15204311;PreProcessorComment
+C%2B%2B\style23\color=6658304
+C%2B%2B\style23\eolfill=false
+C%2B%2B\style23\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style23\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style23\paper=2566178;PreProcessorCommentLineDoc
+C%2B%2B\style24\color=8355584
+C%2B%2B\style24\eolfill=false
+C%2B%2B\style24\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style24\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style24\paper=2566178;
+C%2B%2B\style40\color=11571376
+C%2B%2B\style40\eolfill=false
+C%2B%2B\style40\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style40\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style40\paper=16774143;
+C%2B%2B\style42\color=9482384
+C%2B%2B\style42\eolfill=true
+C%2B%2B\style42\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style42\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style42\paper=14745568;
+C%2B%2B\style44\color=9482384
+C%2B%2B\style44\eolfill=true
+C%2B%2B\style44\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style44\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style44\paper=15204311;
+C%2B%2B\style46\color=10535056
+C%2B%2B\style46\eolfill=false
+C%2B%2B\style46\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style46\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style46\paper=2566178;InactiveDefault
+C%2B%2B\style64\color=12632256
+C%2B%2B\style64\eolfill=false
+C%2B%2B\style64\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style64\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style64\paper=2566178;
+C%2B%2B\style65\color=9482384
+C%2B%2B\style65\eolfill=false
+C%2B%2B\style65\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style65\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style65\paper=2566178;
+C%2B%2B\style66\color=9482384
+C%2B%2B\style66\eolfill=false
+C%2B%2B\style66\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style66\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style66\paper=2566178;
+C%2B%2B\style67\color=13684944
+C%2B%2B\style67\eolfill=false
+C%2B%2B\style67\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style67\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style67\paper=2566178;
+C%2B%2B\style68\color=9482384
+C%2B%2B\style68\eolfill=false
+C%2B%2B\style68\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style68\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style68\paper=2566178;
+C%2B%2B\style69\color=9474224
+C%2B%2B\style69\eolfill=false
+C%2B%2B\style69\font=Consolas, 12, 1, 0, 0
+C%2B%2B\style69\font2=Consolas, 12, 1, 0, 0
+C%2B%2B\style69\paper=2566178;
+C%2B%2B\style70\color=11571376
+C%2B%2B\style70\eolfill=false
+C%2B%2B\style70\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style70\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style70\paper=2566178;
+C%2B%2B\style71\color=11571376
+C%2B%2B\style71\eolfill=false
+C%2B%2B\style71\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style71\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style71\paper=2566178;
+C%2B%2B\style72\color=12632256
+C%2B%2B\style72\eolfill=false
+C%2B%2B\style72\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style72\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style72\paper=2566178;
+C%2B%2B\style73\color=11579536
+C%2B%2B\style73\eolfill=false
+C%2B%2B\style73\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style73\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style73\paper=2566178;
+C%2B%2B\style74\color=11579568
+C%2B%2B\style74\eolfill=false
+C%2B%2B\style74\font=Consolas, 12, 1, 0, 0
+C%2B%2B\style74\font2=Consolas, 12, 1, 0, 0
+C%2B%2B\style74\paper=2566178;
+C%2B%2B\style75\color=11579568
+C%2B%2B\style75\eolfill=false
+C%2B%2B\style75\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style75\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style75\paper=2566178;
+C%2B%2B\style76\color=0
+C%2B%2B\style76\eolfill=true
+C%2B%2B\style76\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style76\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style76\paper=14729440;
+C%2B%2B\style77\color=9482384
+C%2B%2B\style77\eolfill=true
+C%2B%2B\style77\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style77\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style77\paper=14745568;
+C%2B%2B\style78\color=8367999
+C%2B%2B\style78\eolfill=true
+C%2B%2B\style78\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style78\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style78\paper=14741728;
+C%2B%2B\style79\color=12632256
+C%2B%2B\style79\eolfill=false
+C%2B%2B\style79\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style79\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style79\paper=2566178;
+C%2B%2B\style80\color=12632256
+C%2B%2B\style80\eolfill=false
+C%2B%2B\style80\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style80\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style80\paper=2566178;
+C%2B%2B\style81\color=12632256
+C%2B%2B\style81\eolfill=false
+C%2B%2B\style81\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style81\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style81\paper=2566178;
+C%2B%2B\style82\color=12632256
+C%2B%2B\style82\eolfill=false
+C%2B%2B\style82\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style82\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style82\paper=2566178;
+C%2B%2B\style83\color=11579568
+C%2B%2B\style83\eolfill=false
+C%2B%2B\style83\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style83\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style83\paper=2566178;
+C%2B%2B\style88\color=12632256
+C%2B%2B\style88\eolfill=false
+C%2B%2B\style88\font=Consolas, 12, 0, 0, 0
+C%2B%2B\style88\font2=Consolas, 12, 0, 0, 0
+C%2B%2B\style88\paper=2566178
+;
+C%2B%2B\properties\foldatelse=false
+C%2B%2B\properties\foldcomments=false
+C%2B%2B\properties\foldcompact=true
+C%2B%2B\properties\foldpreprocessor=true
+C%2B%2B\properties\stylepreprocessor=false
+C%2B%2B\properties\dollars=true
+C%2B%2B\properties\highlighttriple=false
+C%2B%2B\properties\highlighthash=false
+;
+C%2B%2B\defaultcolor=16777215
+C%2B%2B\defaultpaper=2566178
+C%2B%2B\defaultfont=Consolas, 12, 0, 0, 0
+C%2B%2B\defaultfont2=Consolas, 12, 0, 0, 0
+C%2B%2B\autoindentstyle=-1

--- a/ui/Resources Embedded/defaultTheme.qss
+++ b/ui/Resources Embedded/defaultTheme.qss
@@ -1,0 +1,1219 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) <2013-2014> <Colin Duquesnoy>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+QProgressBar:horizontal {
+    border: 1px solid #3A3939;
+    text-align: center;
+    padding: 1px;
+    background: #201F1F;
+}
+QProgressBar::chunk:horizontal {
+    background-color: qlineargradient(spread:reflect, x1:1, y1:0.545, x2:1, y2:0, stop:0 rgba(28, 66, 111, 255), stop:1 rgba(37, 87, 146, 255));
+}
+
+QToolTip
+{
+    border: 1px solid #3A3939;
+    background-color: rgb(90, 102, 117);;
+    color: white;
+    padding: 1px;
+    opacity: 200;
+}
+
+QWidget
+{
+    color: silver;
+    background-color: #302F2F;
+    selection-background-color:#3d8ec9;
+    selection-color: black;
+    background-clip: border;
+    border-image: none;
+    outline: 0;
+}
+
+QWidget:item:hover
+{
+    background-color: #78879b;
+    color: black;
+}
+
+QWidget:item:selected
+{
+    background-color: #3d8ec9;
+}
+
+QCheckBox
+{
+    spacing: 5px;
+    outline: none;
+    color: #bbb;
+    margin-bottom: 2px;
+}
+
+QCheckBox:disabled
+{
+    color: #777777;
+}
+QCheckBox::indicator,
+QGroupBox::indicator
+{
+    width: 18px;
+    height: 18px;
+}
+QGroupBox::indicator
+{
+    margin-left: 2px;
+}
+
+QCheckBox::indicator:unchecked,
+QCheckBox::indicator:unchecked:hover,
+QGroupBox::indicator:unchecked,
+QGroupBox::indicator:unchecked:hover
+{
+    image: url(:/qss_icons/rc/checkbox_unchecked.png);
+}
+
+QCheckBox::indicator:unchecked:focus,
+QCheckBox::indicator:unchecked:pressed,
+QGroupBox::indicator:unchecked:focus,
+QGroupBox::indicator:unchecked:pressed
+{
+  border: none;
+    image: url(:/qss_icons/rc/checkbox_unchecked_focus.png);
+}
+
+QCheckBox::indicator:checked,
+QCheckBox::indicator:checked:hover,
+QGroupBox::indicator:checked,
+QGroupBox::indicator:checked:hover
+{
+    image: url(:/qss_icons/rc/checkbox_checked.png);
+}
+
+QCheckBox::indicator:checked:focus,
+QCheckBox::indicator:checked:pressed,
+QGroupBox::indicator:checked:focus,
+QGroupBox::indicator:checked:pressed
+{
+  border: none;
+    image: url(:/qss_icons/rc/checkbox_checked_focus.png);
+}
+
+QCheckBox::indicator:indeterminate,
+QCheckBox::indicator:indeterminate:hover,
+QCheckBox::indicator:indeterminate:pressed
+QGroupBox::indicator:indeterminate,
+QGroupBox::indicator:indeterminate:hover,
+QGroupBox::indicator:indeterminate:pressed
+{
+    image: url(:/qss_icons/rc/checkbox_indeterminate.png);
+}
+
+QCheckBox::indicator:indeterminate:focus,
+QGroupBox::indicator:indeterminate:focus
+{
+    image: url(:/qss_icons/rc/checkbox_indeterminate_focus.png);
+}
+
+QCheckBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled
+{
+    image: url(:/qss_icons/rc/checkbox_checked_disabled.png);
+}
+
+QCheckBox::indicator:unchecked:disabled,
+QGroupBox::indicator:unchecked:disabled
+{
+    image: url(:/qss_icons/rc/checkbox_unchecked_disabled.png);
+}
+
+QRadioButton
+{
+    spacing: 5px;
+    outline: none;
+    color: #bbb;
+    margin-bottom: 2px;
+}
+
+QRadioButton:disabled
+{
+    color: #777777;
+}
+QRadioButton::indicator
+{
+    width: 21px;
+    height: 21px;
+}
+
+QRadioButton::indicator:unchecked,
+QRadioButton::indicator:unchecked:hover
+{
+    image: url(:/qss_icons/rc/radio_unchecked.png);
+}
+
+QRadioButton::indicator:unchecked:focus,
+QRadioButton::indicator:unchecked:pressed
+{
+  border: none;
+  outline: none;
+    image: url(:/qss_icons/rc/radio_unchecked_focus.png);
+}
+
+QRadioButton::indicator:checked,
+QRadioButton::indicator:checked:hover
+{
+  border: none;
+  outline: none;
+    image: url(:/qss_icons/rc/radio_checked.png);
+}
+
+QRadioButton::indicator:checked:focus,
+QRadioButton::indicato::menu-arrowr:checked:pressed
+{
+  border: none;
+  outline: none;
+    image: url(:/qss_icons/rc/radio_checked_focus.png);
+}
+
+QRadioButton::indicator:indeterminate,
+QRadioButton::indicator:indeterminate:hover,
+QRadioButton::indicator:indeterminate:pressed
+{
+        image: url(:/qss_icons/rc/radio_indeterminate.png);
+}
+
+QRadioButton::indicator:checked:disabled
+{
+  outline: none;
+  image: url(:/qss_icons/rc/radio_checked_disabled.png);
+}
+
+QRadioButton::indicator:unchecked:disabled
+{
+    image: url(:/qss_icons/rc/radio_unchecked_disabled.png);
+}
+
+
+QMenuBar
+{
+    background-color: #302F2F;
+    color: silver;
+}
+
+QMenuBar::item
+{
+    background: transparent;
+}
+
+QMenuBar::item:selected
+{
+    background: transparent;
+    border: 1px solid #3A3939;
+}
+
+QMenuBar::item:pressed
+{
+    border: 1px solid #3A3939;
+    background-color: #3d8ec9;
+    color: black;
+    margin-bottom:-1px;
+    padding-bottom:1px;
+}
+
+QMenu
+{
+    border: 1px solid #3A3939;
+    color: silver;
+    margin: 2px;
+}
+
+QMenu::icon
+{
+    margin: 5px;
+}
+
+QMenu::item
+{
+    padding: 5px 30px 5px 30px;
+    margin-left: 5px;
+    border: 1px solid transparent; /* reserve space for selection border */
+}
+
+QMenu::item:selected
+{
+    color: black;
+}
+
+QMenu::separator {
+    height: 2px;
+    background: lightblue;
+    margin-left: 10px;
+    margin-right: 5px;
+}
+
+QMenu::indicator {
+    width: 18px;
+    height: 18px;
+}
+
+/* non-exclusive indicator = check box style indicator
+   (see QActionGroup::setExclusive) */
+QMenu::indicator:non-exclusive:unchecked {
+    image: url(:/qss_icons/rc/checkbox_unchecked.png);
+}
+
+QMenu::indicator:non-exclusive:unchecked:selected {
+    image: url(:/qss_icons/rc/checkbox_unchecked_disabled.png);
+}
+
+QMenu::indicator:non-exclusive:checked {
+    image: url(:/qss_icons/rc/checkbox_checked.png);
+}
+
+QMenu::indicator:non-exclusive:checked:selected {
+    image: url(:/qss_icons/rc/checkbox_checked_disabled.png);
+}
+
+/* exclusive indicator = radio button style indicator (see QActionGroup::setExclusive) */
+QMenu::indicator:exclusive:unchecked {
+    image: url(:/qss_icons/rc/radio_unchecked.png);
+}
+
+QMenu::indicator:exclusive:unchecked:selected {
+    image: url(:/qss_icons/rc/radio_unchecked_disabled.png);
+}
+
+QMenu::indicator:exclusive:checked {
+    image: url(:/qss_icons/rc/radio_checked.png);
+}
+
+QMenu::indicator:exclusive:checked:selected {
+    image: url(:/qss_icons/rc/radio_checked_disabled.png);
+}
+
+QMenu::right-arrow {
+    margin: 5px;
+    image: url(:/qss_icons/rc/right_arrow.png)
+}
+
+
+QWidget:disabled
+{
+    color: #404040;
+    background-color: #302F2F;
+}
+
+QAbstractItemView
+{
+    alternate-background-color: #3A3939;
+    color: silver;
+    border: 1px solid 3A3939;
+    border-radius: 2px;
+    padding: 1px;
+}
+
+QWidget:focus, QMenuBar:focus
+{
+    border: 1px solid #78879b;
+}
+
+QTabWidget:focus, QCheckBox:focus, QRadioButton:focus, QSlider:focus
+{
+    border: none;
+}
+
+QLineEdit
+{
+    background-color: #201F1F;
+    padding: 2px;
+    border-style: solid;
+    border: 1px solid #3A3939;
+    border-radius: 2px;
+    color: silver;
+}
+
+QGroupBox {
+    border:1px solid #3A3939;
+    border-radius: 2px;
+    margin-top: 20px;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top center;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 10px;
+}
+
+QAbstractScrollArea
+{
+    border-radius: 2px;
+    border: 1px solid #3A3939;
+    background-color: transparent;
+}
+
+QScrollBar:horizontal
+{
+    height: 15px;
+    margin: 3px 15px 3px 15px;
+    border: 1px transparent #2A2929;
+    border-radius: 4px;
+    background-color: #2A2929;
+}
+
+QScrollBar::handle:horizontal
+{
+    background-color: #605F5F;
+    min-width: 5px;
+    border-radius: 4px;
+}
+
+QScrollBar::add-line:horizontal
+{
+    margin: 0px 3px 0px 3px;
+    border-image: url(:/qss_icons/rc/right_arrow_disabled.png);
+    width: 10px;
+    height: 10px;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:horizontal
+{
+    margin: 0px 3px 0px 3px;
+    border-image: url(:/qss_icons/rc/left_arrow_disabled.png);
+    height: 10px;
+    width: 10px;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:horizontal:hover,QScrollBar::add-line:horizontal:on
+{
+    border-image: url(:/qss_icons/rc/right_arrow.png);
+    height: 10px;
+    width: 10px;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
+}
+
+
+QScrollBar::sub-line:horizontal:hover, QScrollBar::sub-line:horizontal:on
+{
+    border-image: url(:/qss_icons/rc/left_arrow.png);
+    height: 10px;
+    width: 10px;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::up-arrow:horizontal, QScrollBar::down-arrow:horizontal
+{
+    background: none;
+}
+
+
+QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal
+{
+    background: none;
+}
+
+QScrollBar:vertical
+{
+    background-color: #2A2929;
+    width: 15px;
+    margin: 15px 3px 15px 3px;
+    border: 1px transparent #2A2929;
+    border-radius: 4px;
+}
+
+QScrollBar::handle:vertical
+{
+    background-color: #605F5F;
+    min-height: 5px;
+    border-radius: 4px;
+}
+
+QScrollBar::sub-line:vertical
+{
+    margin: 3px 0px 3px 0px;
+    border-image: url(:/qss_icons/rc/up_arrow_disabled.png);
+    height: 10px;
+    width: 10px;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:vertical
+{
+    margin: 3px 0px 3px 0px;
+    border-image: url(:/qss_icons/rc/down_arrow_disabled.png);
+    height: 10px;
+    width: 10px;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:vertical:hover,QScrollBar::sub-line:vertical:on
+{
+
+    border-image: url(:/qss_icons/rc/up_arrow.png);
+    height: 10px;
+    width: 10px;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+}
+
+
+QScrollBar::add-line:vertical:hover, QScrollBar::add-line:vertical:on
+{
+    border-image: url(:/qss_icons/rc/down_arrow.png);
+    height: 10px;
+    width: 10px;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical
+{
+    background: none;
+}
+
+
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical
+{
+    background: none;
+}
+
+QTextEdit
+{
+    background-color: #201F1F;
+    color: silver;
+    border: 1px solid #3A3939;
+}
+
+QPlainTextEdit
+{
+    background-color: #201F1F;;
+    color: silver;
+    border-radius: 2px;
+    border: 1px solid #3A3939;
+}
+
+QHeaderView::section
+{
+    background-color: #3A3939;
+    color: silver;
+    padding-left: 4px;
+    border: 1px solid #6c6c6c;
+}
+
+QSizeGrip {
+    image: url(:/qss_icons/rc/sizegrip.png);
+    width: 12px;
+    height: 12px;
+}
+
+
+QMainWindow::separator
+{
+    background-color: #302F2F;
+    color: white;
+    padding-left: 4px;
+    spacing: 2px;
+    border: 1px dashed #3A3939;
+}
+
+QMainWindow::separator:hover
+{
+
+    background-color: #787876;
+    color: white;
+    padding-left: 4px;
+    border: 1px solid #3A3939;
+    spacing: 2px;
+}
+
+
+QMenu::separator
+{
+    height: 1px;
+    background-color: #3A3939;
+    color: white;
+    padding-left: 4px;
+    margin-left: 10px;
+    margin-right: 5px;
+}
+
+
+QFrame
+{
+    border-radius: 2px;
+    border: 1px solid #444;
+}
+
+QFrame[frameShape="0"]
+{
+    border-radius: 2px;
+    border: 1px transparent #444;
+}
+
+QStackedWidget
+{
+    border: 1px transparent black;
+}
+
+QToolBar {
+    border: 1px transparent #393838;
+    background: 1px solid #302F2F;
+    font-weight: bold;
+}
+
+QToolBar::handle:horizontal {
+    image: url(:/qss_icons/rc/Hmovetoolbar.png);
+}
+QToolBar::handle:vertical {
+    image: url(:/qss_icons/rc/Vmovetoolbar.png);
+}
+QToolBar::separator:horizontal {
+    image: url(:/qss_icons/rc/Hsepartoolbar.png);
+}
+QToolBar::separator:vertical {
+    image: url(:/qss_icons/rc/Vsepartoolbars.png);
+}
+
+QPushButton
+{
+    color: silver;
+    background-color: #302F2F;
+    border-width: 1px;
+    border-color: #4A4949;
+    border-style: solid;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-radius: 2px;
+    outline: none;
+}
+
+QPushButton:disabled
+{
+    background-color: #302F2F;
+    border-width: 1px;
+    border-color: #3A3939;
+    border-style: solid;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 10px;
+    padding-right: 10px;
+    /*border-radius: 2px;*/
+    color: #454545;
+}
+
+QPushButton:focus {
+    background-color: #3d8ec9;
+    color: white;
+}
+
+QComboBox
+{
+    selection-background-color: #3d8ec9;
+    background-color: #201F1F;
+    border-style: solid;
+    border: 1px solid #3A3939;
+    border-radius: 2px;
+    padding: 2px;
+    min-width: 75px;
+}
+
+QPushButton:checked{
+    background-color: #4A4949;
+    border-color: #6A6969;
+}
+
+QComboBox:hover,QPushButton:hover,QAbstractSpinBox:hover,QLineEdit:hover,QTextEdit:hover,QPlainTextEdit:hover,QAbstractView:hover,QTreeView:hover
+{
+    border: 1px solid #78879b;
+    color: silver;
+}
+
+QComboBox:on
+{
+    background-color: #626873;
+    padding-top: 3px;
+    padding-left: 4px;
+    selection-background-color: #4a4a4a;
+}
+
+QComboBox QAbstractItemView
+{
+    background-color: #201F1F;
+    border-radius: 2px;
+    border: 1px solid #444;
+    selection-background-color: #3d8ec9;
+}
+
+QComboBox::drop-down
+{
+    subcontrol-origin: padding;
+    subcontrol-position: top right;
+    width: 15px;
+
+    border-left-width: 0px;
+    border-left-color: darkgray;
+    border-left-style: solid;
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
+}
+
+QComboBox::down-arrow
+{
+    image: url(:/qss_icons/rc/down_arrow_disabled.png);
+}
+
+QComboBox::down-arrow:on, QComboBox::down-arrow:hover,
+QComboBox::down-arrow:focus
+{
+    image: url(:/qss_icons/rc/down_arrow.png);
+}
+
+QPushButton:pressed
+{
+    background-color: #484846;
+}
+
+QAbstractSpinBox {
+    padding-top: 2px;
+    padding-bottom: 2px;
+    border: 1px solid #3A3939;
+    background-color: #201F1F;
+    color: silver;
+    border-radius: 2px;
+    min-width: 75px;
+}
+
+QAbstractSpinBox:up-button
+{
+    background-color: transparent;
+    subcontrol-origin: border;
+    subcontrol-position: center right;
+}
+
+QAbstractSpinBox:down-button
+{
+    background-color: transparent;
+    subcontrol-origin: border;
+    subcontrol-position: center left;
+}
+
+QAbstractSpinBox::up-arrow,QAbstractSpinBox::up-arrow:disabled,QAbstractSpinBox::up-arrow:off {
+    image: url(:/qss_icons/rc/up_arrow_disabled.png);
+    width: 10px;
+    height: 10px;
+}
+QAbstractSpinBox::up-arrow:hover
+{
+    image: url(:/qss_icons/rc/up_arrow.png);
+}
+
+
+QAbstractSpinBox::down-arrow,QAbstractSpinBox::down-arrow:disabled,QAbstractSpinBox::down-arrow:off
+{
+    image: url(:/qss_icons/rc/down_arrow_disabled.png);
+    width: 10px;
+    height: 10px;
+}
+QAbstractSpinBox::down-arrow:hover
+{
+    image: url(:/qss_icons/rc/down_arrow.png);
+}
+
+
+QLabel
+{
+    border: 0px solid black;
+}
+
+QTabWidget{
+    border: 1px transparent black;
+}
+
+QTabWidget::pane {
+    border: 1px solid #444;
+    border-radius: 3px;
+    padding: 3px;
+}
+
+QTabBar
+{
+    qproperty-drawBase: 0;
+    left: 5px; /* move to the right by 5px */
+}
+
+QTabBar:focus
+{
+    border: 0px transparent black;
+}
+
+QTabBar::close-button  {
+    image: url(:/qss_icons/rc/close.png);
+    background: transparent;
+}
+
+QTabBar::close-button:hover
+{
+    image: url(:/qss_icons/rc/close-hover.png);
+    background: transparent;
+}
+
+QTabBar::close-button:pressed {
+    image: url(:/qss_icons/rc/close-pressed.png);
+    background: transparent;
+}
+
+/* TOP TABS */
+QTabBar::tab:top {
+    color: #b1b1b1;
+    border: 1px solid #4A4949;
+    border-bottom: 1px transparent black;
+    background-color: #302F2F;
+    padding: 5px;
+    border-top-left-radius: 2px;
+    border-top-right-radius: 2px;
+}
+
+QTabBar::tab:top:!selected
+{
+    color: #b1b1b1;
+    background-color: #201F1F;
+    border: 1px transparent #4A4949;
+    border-bottom: 1px transparent #4A4949;
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+}
+
+QTabBar::tab:top:!selected:hover {
+    background-color: #48576b;
+}
+
+/* BOTTOM TABS */
+QTabBar::tab:bottom {
+    color: #b1b1b1;
+    border: 1px solid #4A4949;
+    border-top: 1px transparent black;
+    background-color: #302F2F;
+    padding: 5px;
+    border-bottom-left-radius: 2px;
+    border-bottom-right-radius: 2px;
+}
+
+QTabBar::tab:bottom:!selected
+{
+    color: #b1b1b1;
+    background-color: #201F1F;
+    border: 1px transparent #4A4949;
+    border-top: 1px transparent #4A4949;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
+}
+
+QTabBar::tab:bottom:!selected:hover {
+    background-color: #78879b;
+}
+
+/* LEFT TABS */
+QTabBar::tab:left {
+    color: #b1b1b1;
+    border: 1px solid #4A4949;
+    border-left: 1px transparent black;
+    background-color: #302F2F;
+    padding: 5px;
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+}
+
+QTabBar::tab:left:!selected
+{
+    color: #b1b1b1;
+    background-color: #201F1F;
+    border: 1px transparent #4A4949;
+    border-right: 1px transparent #4A4949;
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+}
+
+QTabBar::tab:left:!selected:hover {
+    background-color: #48576b;
+}
+
+
+/* RIGHT TABS */
+QTabBar::tab:right {
+    color: #b1b1b1;
+    border: 1px solid #4A4949;
+    border-right: 1px transparent black;
+    background-color: #302F2F;
+    padding: 5px;
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+}
+
+QTabBar::tab:right:!selected
+{
+    color: #b1b1b1;
+    background-color: #201F1F;
+    border: 1px transparent #4A4949;
+    border-right: 1px transparent #4A4949;
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+}
+
+QTabBar::tab:right:!selected:hover {
+    background-color: #48576b;
+}
+
+QTabBar QToolButton::right-arrow:enabled {
+     image: url(:/qss_icons/rc/right_arrow.png);
+ }
+
+ QTabBar QToolButton::left-arrow:enabled {
+     image: url(:/qss_icons/rc/left_arrow.png);
+ }
+
+QTabBar QToolButton::right-arrow:disabled {
+     image: url(:/qss_icons/rc/right_arrow_disabled.png);
+ }
+
+ QTabBar QToolButton::left-arrow:disabled {
+     image: url(:/qss_icons/rc/left_arrow_disabled.png);
+ }
+
+
+QDockWidget {
+    border: 1px solid #403F3F;
+    titlebar-close-icon: url(:/qss_icons/rc/close.png);
+    titlebar-normal-icon: url(:/qss_icons/rc/undock.png);
+}
+
+QDockWidget::close-button, QDockWidget::float-button {
+    border: 1px solid transparent;
+    border-radius: 2px;
+    background: transparent;
+}
+
+QDockWidget::close-button:hover, QDockWidget::float-button:hover {
+    background: rgba(255, 255, 255, 10);
+}
+
+QDockWidget::close-button:pressed, QDockWidget::float-button:pressed {
+    padding: 1px -1px -1px 1px;
+    background: rgba(255, 255, 255, 10);
+}
+
+QTreeView, QListView
+{
+    border: 1px solid #444;
+    background-color: #201F1F;
+}
+
+QTreeView:branch:selected, QTreeView:branch:hover
+{
+    background: url(:/qss_icons/rc/transparent.png);
+}
+
+QTreeView::branch:has-siblings:!adjoins-item {
+    border-image: url(:/qss_icons/rc/transparent.png);
+}
+
+QTreeView::branch:has-siblings:adjoins-item {
+    border-image: url(:/qss_icons/rc/transparent.png);
+}
+
+QTreeView::branch:!has-children:!has-siblings:adjoins-item {
+    border-image: url(:/qss_icons/rc/transparent.png);
+}
+
+QTreeView::branch:has-children:!has-siblings:closed,
+QTreeView::branch:closed:has-children:has-siblings {
+    image: url(:/qss_icons/rc/branch_closed.png);
+}
+
+QTreeView::branch:open:has-children:!has-siblings,
+QTreeView::branch:open:has-children:has-siblings  {
+    image: url(:/qss_icons/rc/branch_open.png);
+}
+
+QTreeView::branch:has-children:!has-siblings:closed:hover,
+QTreeView::branch:closed:has-children:has-siblings:hover {
+    image: url(:/qss_icons/rc/branch_closed-on.png);
+    }
+
+QTreeView::branch:open:has-children:!has-siblings:hover,
+QTreeView::branch:open:has-children:has-siblings:hover  {
+    image: url(:/qss_icons/rc/branch_open-on.png);
+    }
+
+QListView::item:!selected:hover, QListView::item:!selected:hover, QTreeView::item:!selected:hover  {
+    background: rgba(0, 0, 0, 0);
+    outline: 0;
+    color: #FFFFFF
+}
+
+QListView::item:selected:hover, QListView::item:selected:hover, QTreeView::item:selected:hover  {
+    background: #3d8ec9;
+    color: #FFFFFF;
+}
+
+QSlider::groove:horizontal {
+    border: 1px solid #3A3939;
+    height: 8px;
+    background: #201F1F;
+    margin: 2px 0;
+    border-radius: 2px;
+}
+
+QSlider::handle:horizontal {
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1,
+      stop: 0.0 silver, stop: 0.2 #a8a8a8, stop: 1 #727272);
+    border: 1px solid #3A3939;
+    width: 14px;
+    height: 14px;
+    margin: -4px 0;
+    border-radius: 2px;
+}
+
+QSlider::groove:vertical {
+    border: 1px solid #3A3939;
+    width: 8px;
+    background: #201F1F;
+    margin: 0 0px;
+    border-radius: 2px;
+}
+
+QSlider::handle:vertical {
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0.0 silver,
+      stop: 0.2 #a8a8a8, stop: 1 #727272);
+    border: 1px solid #3A3939;
+    width: 14px;
+    height: 14px;
+    margin: 0 -4px;
+    border-radius: 2px;
+}
+
+QToolButton {
+    background-color: transparent;
+    border: 1px transparent #4A4949;
+    border-radius: 2px;
+    margin: 3px;
+    padding: 3px;
+}
+
+QToolButton[popupMode="1"] { /* only for MenuButtonPopup */
+ padding-right: 20px; /* make way for the popup button */
+ border: 1px transparent #4A4949;
+ border-radius: 5px;
+}
+
+QToolButton[popupMode="2"] { /* only for InstantPopup */
+ padding-right: 10px; /* make way for the popup button */
+ border: 1px transparent #4A4949;
+}
+
+
+QToolButton:hover, QToolButton::menu-button:hover {
+    background-color: transparent;
+    border: 1px solid #78879b;
+}
+
+QToolButton:checked, QToolButton:pressed,
+        QToolButton::menu-button:pressed {
+    background-color: #4A4949;
+    border: 1px solid #78879b;
+}
+
+/* the subcontrol below is used only in the InstantPopup or DelayedPopup mode */
+QToolButton::menu-indicator {
+    image: url(:/qss_icons/rc/down_arrow.png);
+    top: -7px; left: -2px; /* shift it a bit */
+}
+
+/* the subcontrols below are used only in the MenuButtonPopup mode */
+QToolButton::menu-button {
+    border: 1px transparent #4A4949;
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+    /* 16px width + 4px for border = 20px allocated above */
+    width: 16px;
+    outline: none;
+}
+
+QToolButton::menu-arrow {
+    image: url(:/qss_icons/rc/down_arrow.png);
+}
+
+QToolButton::menu-arrow:open {
+    top: 1px; left: 1px; /* shift it a bit */
+    border: 1px solid #3A3939;
+}
+
+QPushButton::menu-indicator  {
+    subcontrol-origin: padding;
+    subcontrol-position: bottom right;
+    left: 8px;
+}
+
+QTableView
+{
+    border: 1px solid #444;
+    gridline-color: #6c6c6c;
+    background-color: #201F1F;
+}
+
+
+QTableView, QHeaderView
+{
+    border-radius: 0px;
+}
+
+QTableView::item:pressed, QListView::item:pressed, QTreeView::item:pressed  {
+    background: #78879b;
+    color: #FFFFFF;
+}
+
+QTableView::item:selected:active, QTreeView::item:selected:active, QListView::item:selected:active  {
+    background: #3d8ec9;
+    color: #FFFFFF;
+}
+
+
+QHeaderView
+{
+    border: 1px transparent;
+    border-radius: 2px;
+    margin: 0px;
+    padding: 0px;
+}
+
+QHeaderView::section  {
+    background-color: #3A3939;
+    color: silver;
+    padding: 4px;
+    border: 1px solid #6c6c6c;
+    border-radius: 0px;
+    text-align: center;
+}
+
+QHeaderView::section::vertical::first, QHeaderView::section::vertical::only-one
+{
+    border-top: 1px solid #6c6c6c;
+}
+
+QHeaderView::section::vertical
+{
+    border-top: transparent;
+}
+
+QHeaderView::section::horizontal::first, QHeaderView::section::horizontal::only-one
+{
+    border-left: 1px solid #6c6c6c;
+}
+
+QHeaderView::section::horizontal
+{
+    border-left: transparent;
+}
+
+
+QHeaderView::section:checked
+ {
+    color: white;
+    background-color: #5A5959;
+ }
+
+ /* style the sort indicator */
+QHeaderView::down-arrow {
+    image: url(:/qss_icons/rc/down_arrow.png);
+}
+
+QHeaderView::up-arrow {
+    image: url(:/qss_icons/rc/up_arrow.png);
+}
+
+
+QTableCornerButton::section {
+    background-color: #3A3939;
+    border: 1px solid #3A3939;
+    border-radius: 2px;
+}
+
+QToolBox  {
+    padding: 3px;
+    border: 1px transparent black;
+}
+
+QToolBox::tab {
+    color: #b1b1b1;
+    background-color: #302F2F;
+    border: 1px solid #4A4949;
+    border-bottom: 1px transparent #302F2F;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+}
+
+ QToolBox::tab:selected { /* italicize selected tabs */
+    font: italic;
+    background-color: #302F2F;
+    border-color: #3d8ec9;
+ }
+
+QStatusBar::item {
+    border: 1px solid #3A3939;
+    border-radius: 2px;
+ }
+
+
+QFrame[height="3"], QFrame[width="3"] {
+    background-color: #444;
+}
+
+
+QSplitter::handle {
+    border: 1px dashed #3A3939;
+}
+
+QSplitter::handle:hover {
+    background-color: #787876;
+    border: 1px solid #3A3939;
+}
+
+QSplitter::handle:horizontal {
+    width: 1px;
+}
+
+QSplitter::handle:vertical {
+    height: 1px;
+}
+

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -365,6 +365,9 @@ private slots:
     void stderrToOutput();
     void makeStarted();
     void makeFinished();
+    void on_actionUI_Theme_triggered();
+    void on_actionEditor_Theme_triggered();
+    void on_actionUI_and_Editor_Theme_triggered();
 };
 
 #endif // MAINWINDOW_H

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -33,7 +33,7 @@ QMainWindow::separator {
      <x>0</x>
      <y>0</y>
      <width>1000</width>
-     <height>31</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -124,11 +124,20 @@ QMainWindow::separator {
     <addaction name="separator"/>
     <addaction name="actionAbout_Gideros_Studio"/>
    </widget>
+   <widget class="QMenu" name="menuSettings">
+    <property name="title">
+     <string>Settings</string>
+    </property>
+    <addaction name="actionUI_Theme"/>
+    <addaction name="actionEditor_Theme"/>
+    <addaction name="actionUI_and_Editor_Theme"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menu_Edit"/>
    <addaction name="menuCompile"/>
    <addaction name="menuPlayer"/>
    <addaction name="menuHelp"/>
+   <addaction name="menuSettings"/>
   </widget>
   <widget class="QToolBar" name="mainToolBar">
    <property name="windowTitle">
@@ -570,6 +579,21 @@ Gideros Player, Play button is enabled.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+P</string>
+   </property>
+  </action>
+  <action name="actionUI_Theme">
+   <property name="text">
+    <string>Load UI Theme</string>
+   </property>
+  </action>
+  <action name="actionEditor_Theme">
+   <property name="text">
+    <string>Load Editor Theme</string>
+   </property>
+  </action>
+  <action name="actionUI_and_Editor_Theme">
+   <property name="text">
+    <string>Load UI and Editor Theme</string>
    </property>
   </action>
  </widget>

--- a/ui/ui.qrc
+++ b/ui/ui.qrc
@@ -6,5 +6,7 @@
         <file>Resources Embedded/landscape_right.png</file>
         <file>Resources Embedded/portrait.png</file>
         <file>Resources Embedded/portrait_upside_down.png</file>
+        <file>Resources Embedded/defaultTheme.ini</file>
+        <file>Resources Embedded/defaultTheme.qss</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
1) UI .qss (QT StyleSheets) themes support.
2) Editor .ini themes support (QScintilla + Lua lexer + C++ lexer).
3) HTML output.
[screenshot1](https://cloud.githubusercontent.com/assets/14117468/10009842/3174df2e-60eb-11e5-8c69-d8982a840cb4.png)
[screenshot2](https://cloud.githubusercontent.com/assets/14117468/10009843/317aa184-60eb-11e5-9ff2-892c36fe5685.png)
[screenshot3](https://cloud.githubusercontent.com/assets/14117468/10009844/317eb9ae-60eb-11e5-9347-2877846d8dfe.png)