### PR TITLE
[desktop] fix setKeepAwake

### DIFF
--- a/libgid/src/qt/platform-qt.cpp
+++ b/libgid/src/qt/platform-qt.cpp
@@ -43,7 +43,7 @@ void setKeepAwake(bool awake)
 {
     if (awake){
         #if defined(Q_OS_WIN)
-            SetThreadExecutionState(ES_DISPLAY_REQUIRED | ES_CONTINUOUS);
+            SetThreadExecutionState(ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED | ES_CONTINUOUS);
             
         #elif defined(Q_OS_MAC)
             if(success == kIOReturnSuccess) {


### PR DESCRIPTION
setKeepAwake probably need to be called periodically for Windows only, because it's just resetting the idle timer. 
Probably good if it is documented