### PR TITLE
textfield improvements

### DIFF
--- a/2dsg/font.cpp
+++ b/2dsg/font.cpp
@@ -145,7 +145,7 @@ void Font::constructor(const char *glympfile, const char *imagefile, bool filter
     }
 }
 
-void Font::drawText(GraphicsBase* graphicsBase, const wchar32_t* text, float r, float g, float b, float letterSpacing) const
+void Font::drawText(GraphicsBase* graphicsBase, const wchar32_t* text, float r, float g, float b, float letterSpacing, float minx, float miny) const
 {
     int size = 0;
     for (const wchar32_t *t = text; *t; ++t, ++size)
@@ -169,7 +169,7 @@ void Font::drawText(GraphicsBase* graphicsBase, const wchar32_t* text, float r, 
 	graphicsBase->texcoords.Update();
 	graphicsBase->indices.Update();
 
-	float x = 0, y = 0;
+    float x = -minx, y = -miny;
     wchar32_t prev = 0;
     for (int i = 0; i < size; ++i)
 	{

--- a/2dsg/font.h
+++ b/2dsg/font.h
@@ -21,7 +21,7 @@ public:
 		return eFont;
 	}
 
-    virtual void drawText(GraphicsBase* graphicsBase, const wchar32_t* text, float r, float g, float b, float letterSpacing) const;
+    virtual void drawText(GraphicsBase* graphicsBase, const wchar32_t* text, float r, float g, float b, float letterSpacing, float minx, float miny) const;
 
     virtual void getBounds(const char *text, float letterSpacing, float *minx, float *miny, float *maxx, float *maxy) const;
     virtual float getAdvanceX(const char *text, float letterSpacing, int size = -1) const;

--- a/2dsg/fontbase.h
+++ b/2dsg/fontbase.h
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    virtual void drawText(GraphicsBase *graphicsBase, const wchar32_t *text, float r, float g, float b, float letterSpacing) const = 0;
+    virtual void drawText(GraphicsBase *graphicsBase, const wchar32_t *text, float r, float g, float b, float letterSpacing, float minx, float miny) const = 0;
 };
 
 

--- a/2dsg/textfield.h
+++ b/2dsg/textfield.h
@@ -16,6 +16,7 @@ public:
     TextField(Application *application);
     TextField(Application *application, BMFontBase* font);
     TextField(Application *application, BMFontBase* font, const char* text);
+    TextField(Application *application, BMFontBase* font, const char* text, const char *sample);
 
 	virtual ~TextField()
 	{
@@ -23,7 +24,7 @@ public:
 			font_->unref();
 	}
 
-	void setFont(Font* font);
+    virtual void setFont(FontBase* font);
 
 	virtual void setText(const char* text);
 	virtual const char* text() const;
@@ -33,6 +34,11 @@ public:
 
     virtual void setLetterSpacing(float letterSpacing);
     virtual float letterSpacing() const;
+
+    virtual float lineHeight() const;
+
+    virtual void setSample(const char* sample);
+    virtual const char* sample() const;
 
 	void createGraphics();
 
@@ -49,6 +55,7 @@ private:
 	GraphicsBase graphicsBase_;
     virtual void doDraw(const CurrentTransform&, float sx, float sy, float ex, float ey);
     float minx_, miny_, maxx_, maxy_;
+    int sminx, sminy, smaxx, smaxy;
 };
 
 #endif

--- a/2dsg/textfieldbase.h
+++ b/2dsg/textfieldbase.h
@@ -4,6 +4,7 @@
 #include "sprite.h"
 
 #include <string>
+#include "font.h"
 #include <wchar32.h>
 
 class Application;
@@ -14,6 +15,8 @@ public:
     TextFieldBase(Application *application) : Sprite(application) {}
     virtual ~TextFieldBase() {}
 
+    virtual void setFont(FontBase* font) = 0;
+
 	virtual void setText(const char* text) = 0;
 	virtual const char* text() const = 0;
 
@@ -23,11 +26,18 @@ public:
     virtual void setLetterSpacing(float letterSpacing) = 0;
     virtual float letterSpacing() const = 0;
 
+    virtual float lineHeight() const = 0;
+
+    virtual void setSample(const char* sample) = 0;
+    virtual const char* sample() const = 0;
+
 protected:
 	void updateWide();
 
 	std::string text_;
+    std::string sample_;
     std::basic_string<wchar32_t> wtext_;
+    std::basic_string<wchar32_t> wsample_;
 };
 
 #endif

--- a/2dsg/ttbmfont.cpp
+++ b/2dsg/ttbmfont.cpp
@@ -254,7 +254,7 @@ TTBMFont::~TTBMFont()
         application_->getTextureManager()->destroyTexture(data_);
 }
 
-void TTBMFont::drawText(GraphicsBase* graphicsBase, const wchar32_t* text, float r, float g, float b, float letterSpacing) const
+void TTBMFont::drawText(GraphicsBase* graphicsBase, const wchar32_t* text, float r, float g, float b, float letterSpacing, float minx, float miny) const
 {
     int size = 0;
     for (const wchar32_t *t = text; *t; ++t, ++size)

--- a/2dsg/ttbmfont.h
+++ b/2dsg/ttbmfont.h
@@ -23,7 +23,7 @@ public:
         return eTTBMFont;
     }
 
-    virtual void drawText(GraphicsBase *graphicsBase, const wchar32_t *text, float r, float g, float b, float letterSpacing) const;
+    virtual void drawText(GraphicsBase *graphicsBase, const wchar32_t *text, float r, float g, float b, float letterSpacing, float minx, float miny) const;
 
     virtual void getBounds(const char *text, float letterSpacing, float *minx, float *miny, float *maxx, float *maxy) const;
     virtual float getAdvanceX(const char *text, float letterSpacing, int size = -1) const;

--- a/2dsg/tttextfield.h
+++ b/2dsg/tttextfield.h
@@ -11,8 +11,11 @@ class TTTextField : public TextFieldBase
 {
 public:
 	TTTextField(Application* application, TTFont* font);
-	TTTextField(Application* application, TTFont* font, const char* text);
+    TTTextField(Application* application, TTFont* font, const char* text);
+    TTTextField(Application* application, TTFont* font, const char* text, const char *sample);
 	virtual ~TTTextField();
+
+    virtual void setFont(FontBase *font);
 
 	virtual void setText(const char* text);
 	virtual const char* text() const;
@@ -22,6 +25,11 @@ public:
 
     virtual void setLetterSpacing(float letterSpacing);
     virtual float letterSpacing() const;
+
+    virtual float lineHeight() const;
+
+    virtual void setSample(const char* sample);
+    virtual const char* sample() const;
 
 private:
 	void createGraphics();
@@ -35,6 +43,7 @@ private:
 	unsigned int textColor_;
     float letterSpacing_;
 	float minx_, miny_, maxx_, maxy_;
+    int sminx, sminy, smaxx, smaxy;
 };
 
 

--- a/luabinding/textfieldbinder.cpp
+++ b/luabinding/textfieldbinder.cpp
@@ -14,12 +14,16 @@ TextFieldBinder::TextFieldBinder(lua_State* L)
 	Binder binder(L);
 
 	static const luaL_Reg functionList[] = {
+        {"setFont", setFont},
 		{"getText", getText},
 		{"setText", setText},
 		{"getTextColor", getTextColor},
 		{"setTextColor", setTextColor},
 		{"getLetterSpacing", getLetterSpacing},
 		{"setLetterSpacing", setLetterSpacing},
+        {"getLineHeight", getLineHeight},
+        {"getSample", getSample},
+        {"setSample", setSample},
 		{NULL, NULL},
 	};
 
@@ -42,19 +46,26 @@ int TextFieldBinder::create(lua_State* L)
 		font = static_cast<FontBase*>(binder.getInstance("FontBase", 1));
 
 	const char* str2 = lua_tostring(L, 2);
+    const char* str3 = lua_tostring(L, 3);
 
     switch (font->getType())
     {
         case FontBase::eFont:
         case FontBase::eTTBMFont:
             if (str2)
-                textField = new TextField(application->getApplication(), static_cast<BMFontBase*>(font), str2);
+                if (str3)
+                    textField = new TextField(application->getApplication(), static_cast<BMFontBase*>(font), str2, str3);
+                else
+                    textField = new TextField(application->getApplication(), static_cast<BMFontBase*>(font), str2);
             else
                 textField = new TextField(application->getApplication(), static_cast<BMFontBase*>(font));
             break;
         case FontBase::eTTFont:
             if (str2)
-                textField = new TTTextField(application->getApplication(), static_cast<TTFont*>(font), str2);
+                if (str3)
+                    textField = new TTTextField(application->getApplication(), static_cast<TTFont*>(font), str2, str3);
+                else
+                    textField = new TTTextField(application->getApplication(), static_cast<TTFont*>(font), str2);
             else
                 textField = new TTTextField(application->getApplication(), static_cast<TTFont*>(font));
             break;
@@ -105,6 +116,21 @@ int TextFieldBinder::destruct(lua_State* L)
 
 	return 0;
 }
+
+
+int TextFieldBinder::setFont(lua_State* L)
+{
+    StackChecker checker(L, "TextFieldBinder::setFont", 0);
+
+    Binder binder(L);
+    TextFieldBase* textField = static_cast<TextFieldBase*>(binder.getInstance("TextField", 1));
+    FontBase* font = static_cast<FontBase*>(binder.getInstance("FontBase", 2));
+
+    textField->setFont(font);
+
+    return 0;
+}
+
 
 int TextFieldBinder::getText(lua_State* L)
 {
@@ -179,4 +205,41 @@ int TextFieldBinder::setLetterSpacing(lua_State* L)
     textField->setLetterSpacing(luaL_checknumber(L, 2));
 
 	return 0;
+}
+
+int TextFieldBinder::getLineHeight(lua_State* L)
+{
+    StackChecker checker(L, "TextFieldBinder::getLineHeight", 1);
+
+    Binder binder(L);
+    TextFieldBase* textField = static_cast<TextFieldBase*>(binder.getInstance("TextField", 1));
+
+    lua_pushnumber(L, textField->lineHeight());
+
+    return 1;
+}
+
+int TextFieldBinder::getSample(lua_State* L)
+{
+    StackChecker checker(L, "TextFieldBinder::getSample", 1);
+
+    Binder binder(L);
+    TextFieldBase* textField = static_cast<TextFieldBase*>(binder.getInstance("TextField", 1));
+
+    lua_pushstring(L, textField->sample());
+
+    return 1;
+}
+
+int TextFieldBinder::setSample(lua_State* L)
+{
+    StackChecker checker(L, "TextFieldBinder::setSample", 0);
+
+    Binder binder(L);
+    TextFieldBase* textField = static_cast<TextFieldBase*>(binder.getInstance("TextField", 1));
+
+    const char* sample = luaL_checkstring(L, 2);
+    textField->setSample(sample);
+
+    return 0;
 }

--- a/luabinding/textfieldbinder.h
+++ b/luabinding/textfieldbinder.h
@@ -12,6 +12,8 @@ private:
 	static int create(lua_State* L);
 	static int destruct(lua_State* L);
 
+    static int setFont(lua_State* L);
+
 	static int getText(lua_State* L);
 	static int setText(lua_State* L);
 
@@ -20,6 +22,11 @@ private:
 
 	static int getLetterSpacing(lua_State* L);
 	static int setLetterSpacing(lua_State* L);
+
+    static int getLineHeight(lua_State* L);
+
+    static int getSample(lua_State* L);
+    static int setSample(lua_State* L);
 };
 
 #endif


### PR DESCRIPTION
Adds optional 'sample' parameter for TextField constructor:
`TextField.new(font, text, sample)`
`sample`: (string, optional) sample to set Y position and line height for a text.

Adds 4 new methods:
setFont(font) -- font should be either bitmap or true type font
setSample(sample) -- sample should be a string
getSample() -- returns sample string
getLineHeight() -- returns height of the sample as a number

