### PR TITLE
lua type metatables powerpatch

### DIFF
--- a/lua/src/lapi.c
+++ b/lua/src/lapi.c
@@ -693,6 +693,22 @@ LUA_API void lua_rawseti (lua_State *L, int idx, int n) {
   lua_unlock(L);
 }
 
+LUA_API int lua_settypemt (lua_State *L, int type) {
+    Table *mt;
+    lua_lock(L);
+    api_checknelems(L, 1);
+    api_check(L, ((type >= 0) && (type < LUA_NUMTAGS)));
+    if (ttisnil(L->top - 1))
+      mt = NULL;
+    else {
+      api_check(L, ttistable(L->top - 1));
+      mt = hvalue(L->top - 1);
+    }
+    G(L)->mt[type] = mt;
+    L->top--;
+    lua_unlock(L);
+    return 1;
+}
 
 LUA_API int lua_setmetatable (lua_State *L, int objindex) {
   TValue *obj;

--- a/lua/src/ldblib.c
+++ b/lua/src/ldblib.c
@@ -44,6 +44,22 @@ static int db_setmetatable (lua_State *L) {
 }
 
 
+static char* db_types[] = {"nil","boolean","lightuserdata",
+  "number","string","table","function","userdata","thread",NULL};
+
+
+static int db_settypemt (lua_State *L) {
+  int ty = luaL_checkoption(L, 1, NULL, db_types);
+  int t = lua_type(L, 2);
+  luaL_argcheck(L, t == LUA_TNIL || t == LUA_TTABLE, 2,
+    "nil or table expected");
+  lua_remove(L, 1);
+  lua_settop(L, 1);
+  lua_settypemt(L, ty);
+  return 0;
+}
+
+
 static int db_getfenv (lua_State *L) {
   lua_getfenv(L, 1);
   return 1;
@@ -384,6 +400,7 @@ static const luaL_Reg dblib[] = {
   {"sethook", db_sethook},
   {"setlocal", db_setlocal},
   {"setmetatable", db_setmetatable},
+  {"settypemt", db_settypemt},
   {"setupvalue", db_setupvalue},
   {"traceback", db_errorfb},
   {NULL, NULL}

--- a/lua/src/lstring.c
+++ b/lua/src/lstring.c
@@ -101,7 +101,10 @@ Udata *luaS_newudata (lua_State *L, size_t s, Table *e) {
   u->uv.marked = luaC_white(G(L));  /* is not finalized */
   u->uv.tt = LUA_TUSERDATA;
   u->uv.len = s;
-  u->uv.metatable = NULL;
+  u->uv.metatable = G(L)->mt[LUA_TUSERDATA];
+  if (u->uv.metatable) {
+    luaC_objbarrier(L, u, u->uv.metatable);
+  }
   u->uv.env = e;
   /* chain it on udata list (after main thread) */
   u->uv.next = G(L)->mainthread->next;

--- a/lua/src/ltable.c
+++ b/lua/src/ltable.c
@@ -358,7 +358,11 @@ static void rehash (lua_State *L, Table *t, const TValue *ek) {
 Table *luaH_new (lua_State *L, int narray, int nhash) {
   Table *t = luaM_new(L, Table);
   luaC_link(L, obj2gco(t), LUA_TTABLE);
-  t->metatable = NULL;
+  //t->metatable = NULL;
+  t->metatable = G(L)->mt[LUA_TTABLE];
+  if (t->metatable) {
+    luaC_objbarriert(L, t, t->metatable);
+  }
   t->flags = cast_byte(~0);
   /* temporary values (kept only if some malloc fails) */
   t->array = NULL;

--- a/lua/src/ltablib.c
+++ b/lua/src/ltablib.c
@@ -279,9 +279,14 @@ static const luaL_Reg tab_funcs[] = {
   {NULL, NULL}
 };
 
-
 LUALIB_API int luaopen_table (lua_State *L) {
   luaL_register(L, LUA_TABLIBNAME, tab_funcs);
+  lua_createtable(L, 0, 1);  /* table to be type metatable for tables */
+  lua_pushvalue(L, -1);      /* copy table */
+  lua_settypemt(L, LUA_TTABLE);   /* set table as type metatable for tables */
+  lua_pushvalue(L, -2);      /* get table library */
+  lua_setfield(L, -2, "__index");  /* metatable.__index = table */
+  lua_pop(L, 1);			 /* pop metatable */
   return 1;
 }
 

--- a/lua/src/lua.h
+++ b/lua/src/lua.h
@@ -192,6 +192,7 @@ LUA_API void  (lua_setfield) (lua_State *L, int idx, const char *k);
 LUA_API void  (lua_rawset) (lua_State *L, int idx);
 LUA_API void  (lua_rawseti) (lua_State *L, int idx, int n);
 LUA_API int   (lua_setmetatable) (lua_State *L, int objindex);
+LUA_API int   (lua_settypemt) (lua_State *L, int type);
 LUA_API int   (lua_setfenv) (lua_State *L, int idx);
 
 


### PR DESCRIPTION
From http://lua-users.org/wiki/LuaPowerPatches
Useful to extend Lua syntax and for some tricks.

Adds new method to `debug` library:
`debug.settypemt(type, metatable)`
Supported types: "nil","boolean","lightuserdata","number","string","table","function","userdata","thread".

For example:
```lua
-- enable string indexing (s[n]) to get character at utf8 position
string.__index = function(s, n) return utf8.sub(s, n, n) end
debug.settypemt("string", string)
local s = "Hello, world!"
print(s[8]) --> w
```

Also sets `table` library as default type metatable for all tables without user defined metatables i.e. enables following syntax: `t:insert(3); t:remove(2); t:sort(func);` etc.