### PR TITLE
Lua macro implementation

### DIFF
--- a/lua/src/llex.c
+++ b/lua/src/llex.c
@@ -24,25 +24,22 @@
 #include "lzio.h"
 
 
-
-#define next(ls) (ls->current = zgetc(ls->z))
-
-
-
+#define next(ls) (ls->current = ls->mpos < ls->mlen ? char2int(ls->mstr[ls->mpos++]) : zgetc(ls->z))
 
 #define currIsNewline(ls)	(ls->current == '\n' || ls->current == '\r')
 
+#define MACRO "MACRO"
 
 /* ORDER RESERVED */
 const char *const luaX_tokens [] = {
-    "and", "break", "do", "else", "elseif",
-    "end", "false", "for", "function", "if",
-    "in", "local", "nil", "not", "or", "repeat",
-    "return", "then", "true", "until", "while",
-    "..", "...", "==", ">=", "<=", "~=", "!=",
-    "<<", ">>", "//",
-    "<number>", "<name>", "<string>", "<eof>",
-    NULL
+  "and", "break", "do", "else", "elseif",
+  "end", "false", "for", "function", "if",
+  "in", "local", "nil", "not", "or", "repeat",
+  "return", "then", "true", "until", "while",
+  "..", "...", "==", ">=", "<=", "~=",
+  "<<", ">>", "//",
+  "<number>", "<name>", "<string>", "<eof>",
+  NULL
 };
 
 
@@ -89,13 +86,13 @@ const char *luaX_token2str (LexState *ls, int token) {
 
 static const char *txtToken (LexState *ls, int token) {
   switch (token) {
-    case TK_NAME:
-    case TK_STRING:
-    case TK_NUMBER:
-      save(ls, '\0');
-      return luaZ_buffer(ls->buff);
-    default:
-      return luaX_token2str(ls, token);
+  case TK_NAME:
+  case TK_STRING:
+  case TK_NUMBER:
+    save(ls, '\0');
+    return luaZ_buffer(ls->buff);
+  default:
+    return luaX_token2str(ls, token);
   }
 }
 
@@ -131,6 +128,7 @@ static void inclinenumber (LexState *ls) {
   next(ls);  /* skip `\n' or `\r' */
   if (currIsNewline(ls) && ls->current != old)
     next(ls);  /* skip `\n\r' or `\r\n' */
+  if (ls->mpos < ls->mlen) return;
   if (++ls->linenumber >= MAX_INT)
     luaX_syntaxerror(ls, "chunk has too many lines");
 }
@@ -231,50 +229,50 @@ static void read_long_string (LexState *ls, SemInfo *seminfo, int sep) {
     inclinenumber(ls);  /* skip it */
   for (;;) {
     switch (ls->current) {
-      case EOZ:
-        luaX_lexerror(ls, (seminfo) ? "unfinished long string" :
-                                   "unfinished long comment", TK_EOS);
-        break;  /* to avoid warnings */
+    case EOZ:
+      luaX_lexerror(ls, (seminfo) ? "unfinished long string" :
+                                    "unfinished long comment", TK_EOS);
+      break;  /* to avoid warnings */
 #if defined(LUA_COMPAT_LSTR)
-      case '[': {
-        if (skip_sep(ls) == sep) {
-          save_and_next(ls);  /* skip 2nd `[' */
-          cont++;
+    case '[': {
+      if (skip_sep(ls) == sep) {
+        save_and_next(ls);  /* skip 2nd `[' */
+        cont++;
 #if LUA_COMPAT_LSTR == 1
-          if (sep == 0)
-            luaX_lexerror(ls, "nesting of [[...]] is deprecated", '[');
+        if (sep == 0)
+          luaX_lexerror(ls, "nesting of [[...]] is deprecated", '[');
 #endif
-        }
-        break;
       }
+      break;
+    }
 #endif
-      case ']': {
-        if (skip_sep(ls) == sep) {
-          save_and_next(ls);  /* skip 2nd `]' */
+    case ']': {
+      if (skip_sep(ls) == sep) {
+        save_and_next(ls);  /* skip 2nd `]' */
 #if defined(LUA_COMPAT_LSTR) && LUA_COMPAT_LSTR == 2
-          cont--;
-          if (sep == 0 && cont >= 0) break;
+        cont--;
+        if (sep == 0 && cont >= 0) break;
 #endif
-          goto endloop;
-        }
-        break;
+        goto endloop;
       }
-      case '\n':
-      case '\r': {
-        save(ls, '\n');
-        inclinenumber(ls);
-        if (!seminfo) luaZ_resetbuffer(ls->buff);  /* avoid wasting space */
-        break;
-      }
-      default: {
-        if (seminfo) save_and_next(ls);
-        else next(ls);
-      }
+      break;
+    }
+    case '\n':
+    case '\r': {
+      save(ls, '\n');
+      inclinenumber(ls);
+      if (!seminfo) luaZ_resetbuffer(ls->buff);  /* avoid wasting space */
+      break;
+    }
+    default: {
+      if (seminfo) save_and_next(ls);
+      else next(ls);
+    }
     }
   } endloop:
-  if (seminfo)
-    seminfo->ts = luaX_newstring(ls, luaZ_buffer(ls->buff) + (2 + sep),
-                                     luaZ_bufflen(ls->buff) - 2*(2 + sep));
+    if (seminfo)
+  seminfo->ts = luaX_newstring(ls, luaZ_buffer(ls->buff) + (2 + sep),
+    luaZ_bufflen(ls->buff) - 2*(2 + sep));
 }
 
 
@@ -282,55 +280,55 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
   save_and_next(ls);
   while (ls->current != del) {
     switch (ls->current) {
-      case EOZ:
-        luaX_lexerror(ls, "unfinished string", TK_EOS);
-        continue;  /* to avoid warnings */
-      case '\n':
-      case '\r':
-        luaX_lexerror(ls, "unfinished string", TK_STRING);
-        continue;  /* to avoid warnings */
-      case '\\': {
-        int c;
-        next(ls);  /* do not save the `\' */
-        switch (ls->current) {
-          case 'a': c = '\a'; break;
-          case 'b': c = '\b'; break;
-          case 'f': c = '\f'; break;
-          case 'n': c = '\n'; break;
-          case 'r': c = '\r'; break;
-          case 't': c = '\t'; break;
-          case 'v': c = '\v'; break;
-          case '\n':  /* go through */
-          case '\r': save(ls, '\n'); inclinenumber(ls); continue;
-          case EOZ: continue;  /* will raise an error next loop */
-          default: {
-            if (!isdigit(ls->current))
-              save_and_next(ls);  /* handles \\, \", \', and \? */
-            else {  /* \xxx */
-              int i = 0;
-              c = 0;
-              do {
-                c = 10*c + (ls->current-'0');
-                next(ls);
-              } while (++i<3 && isdigit(ls->current));
-              if (c > UCHAR_MAX)
-                luaX_lexerror(ls, "escape sequence too large", TK_STRING);
-              save(ls, c);
-            }
-            continue;
-          }
+    case EOZ:
+      luaX_lexerror(ls, "unfinished string", TK_EOS);
+      continue;  /* to avoid warnings */
+    case '\n':
+    case '\r':
+      luaX_lexerror(ls, "unfinished string", TK_STRING);
+      continue;  /* to avoid warnings */
+    case '\\': {
+      int c;
+      next(ls);  /* do not save the `\' */
+      switch (ls->current) {
+      case 'a': c = '\a'; break;
+      case 'b': c = '\b'; break;
+      case 'f': c = '\f'; break;
+      case 'n': c = '\n'; break;
+      case 'r': c = '\r'; break;
+      case 't': c = '\t'; break;
+      case 'v': c = '\v'; break;
+      case '\n':  /* go through */
+      case '\r': save(ls, '\n'); inclinenumber(ls); continue;
+      case EOZ: continue;  /* will raise an error next loop */
+      default: {
+        if (!isdigit(ls->current))
+          save_and_next(ls);  /* handles \\, \", \', and \? */
+        else {  /* \xxx */
+          int i = 0;
+          c = 0;
+          do {
+            c = 10*c + (ls->current-'0');
+            next(ls);
+          } while (++i<3 && isdigit(ls->current));
+          if (c > UCHAR_MAX)
+            luaX_lexerror(ls, "escape sequence too large", TK_STRING);
+          save(ls, c);
         }
-        save(ls, c);
-        next(ls);
         continue;
       }
-      default:
-        save_and_next(ls);
+      }
+      save(ls, c);
+      next(ls);
+      continue;
+    }
+    default:
+      save_and_next(ls);
     }
   }
   save_and_next(ls);  /* skip delimiter */
   seminfo->ts = luaX_newstring(ls, luaZ_buffer(ls->buff) + 1,
-                                   luaZ_bufflen(ls->buff) - 2);
+                               luaZ_bufflen(ls->buff) - 2);
 }
 
 
@@ -338,123 +336,296 @@ static int llex (LexState *ls, SemInfo *seminfo) {
   luaZ_resetbuffer(ls->buff);
   for (;;) {
     switch (ls->current) {
-      case '\n':
-      case '\r': {
-        inclinenumber(ls);
-        continue;
-      }
-      case '-': {
-        next(ls);
-        if (ls->current != '-') return '-';
-        /* else is a comment */
-        next(ls);
-        if (ls->current == '[') {
-          int sep = skip_sep(ls);
-          luaZ_resetbuffer(ls->buff);  /* `skip_sep' may dirty the buffer */
-          if (sep >= 0) {
-            read_long_string(ls, NULL, sep);  /* long comment */
-            luaZ_resetbuffer(ls->buff);
-            continue;
-          }
-        }
-        /* else short comment */
-        while (!currIsNewline(ls) && ls->current != EOZ)
-          next(ls);
-        continue;
-      }
-      case '[': {
-        int sep = skip_sep(ls);
-        if (sep >= 0) {
-          read_long_string(ls, seminfo, sep);
-          return TK_STRING;
-        }
-        else if (sep == -1) return '[';
-        else luaX_lexerror(ls, "invalid long string delimiter", TK_STRING);
-      }
-      case '=': {
-        next(ls);
-        if (ls->current != '=') return '=';
-        else { next(ls); return TK_EQ; }
-      }
-      case '<': {
+    case '\n':
+    case '\r': {
+      inclinenumber(ls);
+      continue;
+    }
+    case '-': {
       next(ls);
-      if (ls->current == '=') { next(ls); return TK_LE; }
-        else if (ls->current == '<') { next(ls); return TK_LSHFT; }
-        else  return '<';
-      }
-      case '>': {
-        next(ls);
-        if (ls->current == '=') { next(ls); return TK_GE; }
-        else if (ls->current == '>') { next(ls); return TK_RSHFT; }
-       else return '>';
-      }
-      case '/': {
-        next(ls);
-        if (ls->current != '/') return '/';
-        else { next(ls); return TK_INTDIV; }
-      }
-      case '~': {
-        next(ls);
-        if (ls->current != '=') return '~';
-        else { next(ls); return TK_NE; }
-      }
-      case '!': {
-        next(ls);
-        if (ls->current != '=') return '!';
-        else { next(ls); return TK_NE; }
-      }
-      case '"':
-      case '\'': {
-        read_string(ls, ls->current, seminfo);
-        return TK_STRING;
-      }
-      case '.': {
-        save_and_next(ls);
-        if (check_next(ls, ".")) {
-          if (check_next(ls, "."))
-            return TK_DOTS;   /* ... */
-          else return TK_CONCAT;   /* .. */
-        }
-        else if (!isdigit(ls->current)) return '.';
-        else {
-          read_numeral(ls, seminfo);
-          return TK_NUMBER;
-        }
-      }
-      case EOZ: {
-        return TK_EOS;
-      }
-      default: {
-        if (isspace(ls->current)) {
-          lua_assert(!currIsNewline(ls));
-          next(ls);
+      if (ls->current != '-') return '-';
+      /* else is a comment */
+      next(ls);
+      if (ls->current == '[') {
+        int sep = skip_sep(ls);
+        luaZ_resetbuffer(ls->buff);  /* `skip_sep' may dirty the buffer */
+        if (sep >= 0) {
+          read_long_string(ls, NULL, sep);  /* long comment */
+          luaZ_resetbuffer(ls->buff);
           continue;
         }
-        else if (isdigit(ls->current)) {
-          read_numeral(ls, seminfo);
-          return TK_NUMBER;
-        }
-        else if (isalpha(ls->current) || ls->current == '_') {
-          /* identifier or reserved word */
-          TString *ts;
-          do {
-            save_and_next(ls);
-          } while (isalnum(ls->current) || ls->current == '_');
-          ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
-                                  luaZ_bufflen(ls->buff));
-          if (ts->tsv.reserved > 0)  /* reserved word? */
-            return ts->tsv.reserved - 1 + FIRST_RESERVED;
-          else {
-            seminfo->ts = ts;
-            return TK_NAME;
-          }
-        }
-        else {
-          int c = ls->current;
-          next(ls);
-          return c;  /* single-char tokens (+ - / ...) */
-        }
       }
+      /* else short comment */
+      while (!currIsNewline(ls) && ls->current != EOZ)
+        next(ls);
+      continue;
+    }
+    case '[': {
+      int sep = skip_sep(ls);
+      if (sep >= 0) {
+        read_long_string(ls, seminfo, sep);
+        return TK_STRING;
+      }
+      else if (sep == -1) return '[';
+      else luaX_lexerror(ls, "invalid long string delimiter", TK_STRING);
+    }
+    case '=': {
+      next(ls);
+      if (ls->current != '=') return '=';
+      else { next(ls); return TK_EQ; }
+    }
+    case '<': {
+      next(ls);
+      if (ls->current == '=') { next(ls); return TK_LE; }
+      else if (ls->current == '<') { next(ls); return TK_LSHFT; }
+      else  return '<';
+    }
+    case '>': {
+      next(ls);
+      if (ls->current == '=') { next(ls); return TK_GE; }
+      else if (ls->current == '>') { next(ls); return TK_RSHFT; }
+      else return '>';
+    }
+    case '/': {
+      next(ls);
+      if (ls->current != '/') return '/';
+      else { next(ls); return TK_INTDIV; }
+    }
+    case '~': {
+      next(ls);
+      if (ls->current != '=') return '~';
+      else { next(ls); return TK_NE; }
+    }
+    case '!': {
+      luaX_lexerror(ls, "assembler support is not implemented yet", 0);
+    }
+    case '"':
+    case '\'': {
+      read_string(ls, ls->current, seminfo);
+      return TK_STRING;
+    }
+    case '.': {
+      save_and_next(ls);
+      if (check_next(ls, ".")) {
+        if (check_next(ls, "."))
+          return TK_DOTS;   /* ... */
+        else return TK_CONCAT;   /* .. */
+      }
+      else if (!isdigit(ls->current)) return '.';
+      else {
+        read_numeral(ls, seminfo);
+        return TK_NUMBER;
+      }
+    }
+    case '@': {
+      luaX_lexerror(ls, "invalid macro identifier", 0);
+    }
+    case EOZ: {
+      return TK_EOS;
+    }
+    default: {
+      if (isspace(ls->current)) {
+        lua_assert(!currIsNewline(ls));
+        next(ls);
+        continue;
+      }
+      else if (isdigit(ls->current)) {
+        read_numeral(ls, seminfo);
+        return TK_NUMBER;
+      }
+      else if (isalpha(ls->current) || ls->current == '_') {
+        TString *ts;
+        do {
+          save_and_next(ls);
+        } while (isalnum(ls->current) || ls->current == '_');
+        ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
+                            luaZ_bufflen(ls->buff));
+        while (isspace(ls->current)) {
+          if (ls->current == '\n') ++ls->linenumber;
+          next(ls);
+        }
+        if (ls->current == '@') {
+          if (ts->tsv.reserved > 0)
+            luaX_lexerror(ls, "invalid macro identifier",
+                          ts->tsv.reserved - 1 + FIRST_RESERVED);
+          lua_State *L = ls->L;
+          lua_getglobal(L, MACRO);
+
+          if(!lua_istable(L,-1))
+          {
+            lua_pop(L, 1);
+            lua_newtable(L);
+            lua_setglobal(L, MACRO);
+            lua_getglobal(L, MACRO);
+          }
+          next(ls);
+          save(ls, '\0');
+          char *key = malloc(strlen(ls->buff->buffer) + 1);
+          if (key) strcpy(key, ls->buff->buffer);
+          else luaX_lexerror(ls, "cannot allocate enough memory",0);
+          lua_pushstring(L, key);
+          lua_gettable(L, -2);
+          if (!lua_isnil(L, -1))
+          {
+            if (ls->current != '@')
+              luaX_lexerror(ls, "definition of existent macro", 0);
+          } else if (ls->current == '@')
+            luaX_lexerror(ls, "redefinition of nonexistent macro", 0);
+          if (ls->current == '@') next(ls);
+          lua_pop(L, 1);
+          lua_pushstring(L, key);
+          luaZ_resetbuffer(ls->buff);
+          while (isspace(ls->current))
+          {
+            if (ls->current == '\n') ++ls->linenumber;
+            next(ls);
+          }
+          char q = ls->current;
+          switch (q)
+          {
+          case '\'':
+          case '"':
+          {
+            save_and_next(ls);
+            while (ls->current != q)
+            {
+              if (ls->current == EOZ)
+                luaX_lexerror(ls, "unfinished string at macro definition", 0);
+              if (ls->current == '\n')
+                luaX_lexerror(ls, "unfinished string at macro definition", TK_STRING);
+              save_and_next(ls);
+            }
+            save_and_next(ls);
+            break;
+          }
+          case '[':
+          {
+            save_and_next(ls);
+            if (ls->current != '[' && ls->current != '=')
+              luaX_lexerror(ls, "invalid long string at macro definition", 0);
+            int eqlen = 0;
+            int eqnum = 0;
+            while (ls->current == '=') {eqlen++; save_and_next(ls);};
+            if (eqlen > 0 && ls->current != '[')
+              luaX_lexerror(ls, "invalid long string at macro definition", 0);
+            save_and_next(ls);
+            for(;;)
+            {
+              switch (ls->current)
+              {
+              case EOZ:
+                luaX_lexerror(ls, "unfinished long string at macro definition", 0);
+                break;
+              case '\n':
+                ls->linenumber++;
+                break;
+              case '=':
+                ++eqnum;
+                break;
+              case ']':
+                if (eqnum == -1) eqnum = 0;
+              }
+              if (ls->current != '=' && ls->current != ']') eqnum = -1;
+              save_and_next(ls);
+              if (eqnum == eqlen && ls->current == ']')
+              {
+                save_and_next(ls);
+                break;
+              }
+            }
+            break;
+          }
+          case '-': case '0': case '1': case '2': case '3': case '4':
+          case '.': case '5': case '6': case '7': case '8': case '9':
+          {
+            while (!isspace(ls->current)) save_and_next(ls);
+            break;
+          }
+          case '`': case '~': case '!': case '#': case '$': case '%': case '^':
+          case '&': case '*': case '/': case '+': case '=': case '|': case '\\':
+          {
+            next(ls);
+            while (ls->current != q)
+            {
+              if (ls->current == EOZ)
+                luaX_lexerror(ls, "unfinished macro definition", 0);
+              if (ls->current == '\n') ++ls->linenumber;
+              save_and_next(ls);
+            }
+            next(ls);
+            break;
+          }
+          default:
+          {
+            if (isalpha(ls->current) || ls->current == '_') {
+              do {
+                save_and_next(ls);
+              } while (isalnum(ls->current) || ls->current == '_');
+            } else luaX_lexerror(ls, "invalid macro marker", 0);
+          }
+          }
+          save(ls, ' ');
+          save(ls, '\0');
+          char *val = malloc(strlen(ls->buff->buffer) + 1);
+          if(val) strcpy(val, ls->buff->buffer);
+          lua_pushstring(L, val);
+          luaZ_resetbuffer(ls->buff);
+          lua_rawset(L, -3);
+          lua_setglobal(L, MACRO);
+          free(key);
+          free(val);
+          continue;
+        }
+        if (ts->tsv.reserved > 0)  /* reserved word? */
+          return ts->tsv.reserved - 1 + FIRST_RESERVED;
+        lua_State *L = ls->L;
+        lua_getglobal(L, MACRO);
+        if (lua_istable(L, -1)) {
+          save(ls, '\0');
+          char *k = ls->buff->buffer;
+          lua_getfield(L, -1, k);
+          if (lua_isstring(L, -1)) {
+            luaZ_resetbuffer(ls->buff);
+            char *s = lua_tostring(L, -1);
+            if (ls->mpos < ls->mlen) {
+              int len = strlen(s) + ls->mlen - ls->mpos + 1;
+              char *res = (char*) malloc(len);
+              strcpy(res, s);
+              strcat(res, &ls->mstr[ls->mpos-1]);
+              strcat(res, " ");
+              free(ls->mstr);
+              free(s);
+              ls->mstr = res;
+              ls->z->n--; ls->z->p++;
+            }
+            else {
+              if (ls->mlen > 0) free(ls->mstr);
+              ls->mstr = s;
+            }
+            ls->mpos = 1;
+            ls->mlen = strlen(ls->mstr);
+            if (ls->mlen > 0) {
+              ls->current = ls->mstr[0];
+              ls->z->n++; ls->z->p--;
+            }
+            lua_pop(L, 1);
+            lua_pop(L, 1);
+            if (ls->mswt++ > 1e6) luaX_lexerror(ls, "possible mutual macro recursion", 0);
+            continue;
+          }
+          lua_pop(L, 1);
+        }
+        lua_pop(L, 1);
+
+        seminfo->ts = ts;
+        return TK_NAME;
+      }
+      else {
+        int c = ls->current;
+        next(ls);
+        return c;  /* single-char tokens (+ - / ...) */
+      }
+    }
     }
   }
 }

--- a/lua/src/llex.h
+++ b/lua/src/llex.h
@@ -28,7 +28,7 @@ enum RESERVED {
   TK_IF, TK_IN, TK_LOCAL, TK_NIL, TK_NOT, TK_OR, TK_REPEAT,
   TK_RETURN, TK_THEN, TK_TRUE, TK_UNTIL, TK_WHILE,
   /* other terminal symbols */
-  TK_CONCAT, TK_DOTS, TK_EQ, TK_GE, TK_LE, TK_NE, TK_CNE,
+  TK_CONCAT, TK_DOTS, TK_EQ, TK_GE, TK_LE, TK_NE,
   TK_LSHFT, TK_RSHFT, TK_INTDIV,
   TK_NUMBER, TK_NAME, TK_STRING, TK_EOS
 };
@@ -65,6 +65,10 @@ typedef struct LexState {
   Mbuffer *buff;  /* buffer for tokens */
   TString *source;  /* current source name */
   char decpoint;  /* locale decimal point */
+  char *mstr; /* macro string */
+  int mpos; /* current character position of macro string */
+  int mlen; /* macro string length */
+  int mswt; /* number of switches between source and macro */
 } LexState;
 
 

--- a/lua/src/lparser.c
+++ b/lua/src/lparser.c
@@ -383,6 +383,10 @@ static void close_func (LexState *ls) {
 Proto *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff, const char *name) {
   struct LexState lexstate;
   struct FuncState funcstate;
+  lexstate.mstr = "";
+  lexstate.mpos = 0;
+  lexstate.mlen = 0;
+  lexstate.mswt = 0;
   lexstate.buff = buff;
   luaX_setinput(L, &lexstate, z, luaS_new(L, name));
   open_func(&lexstate, &funcstate);

--- a/lua514u/src/llex.c
+++ b/lua514u/src/llex.c
@@ -24,25 +24,22 @@
 #include "lzio.h"
 
 
-
-#define next(ls) (ls->current = zgetc(ls->z))
-
-
-
+#define next(ls) (ls->current = ls->mpos < ls->mlen ? char2int(ls->mstr[ls->mpos++]) : zgetc(ls->z))
 
 #define currIsNewline(ls)	(ls->current == '\n' || ls->current == '\r')
 
+#define MACRO "MACRO"
 
 /* ORDER RESERVED */
 const char *const luaX_tokens [] = {
-    "and", "break", "do", "else", "elseif",
-    "end", "false", "for", "function", "if",
-    "in", "local", "nil", "not", "or", "repeat",
-    "return", "then", "true", "until", "while",
-    "..", "...", "==", ">=", "<=", "~=", "!=",
-    "<<", ">>", "//",
-    "<number>", "<name>", "<string>", "<eof>",
-    NULL
+  "and", "break", "do", "else", "elseif",
+  "end", "false", "for", "function", "if",
+  "in", "local", "nil", "not", "or", "repeat",
+  "return", "then", "true", "until", "while",
+  "..", "...", "==", ">=", "<=", "~=",
+  "<<", ">>", "//",
+  "<number>", "<name>", "<string>", "<eof>",
+  NULL
 };
 
 
@@ -89,13 +86,13 @@ const char *luaX_token2str (LexState *ls, int token) {
 
 static const char *txtToken (LexState *ls, int token) {
   switch (token) {
-    case TK_NAME:
-    case TK_STRING:
-    case TK_NUMBER:
-      save(ls, '\0');
-      return luaZ_buffer(ls->buff);
-    default:
-      return luaX_token2str(ls, token);
+  case TK_NAME:
+  case TK_STRING:
+  case TK_NUMBER:
+    save(ls, '\0');
+    return luaZ_buffer(ls->buff);
+  default:
+    return luaX_token2str(ls, token);
   }
 }
 
@@ -131,6 +128,7 @@ static void inclinenumber (LexState *ls) {
   next(ls);  /* skip `\n' or `\r' */
   if (currIsNewline(ls) && ls->current != old)
     next(ls);  /* skip `\n\r' or `\r\n' */
+  if (ls->mpos < ls->mlen) return;
   if (++ls->linenumber >= MAX_INT)
     luaX_syntaxerror(ls, "chunk has too many lines");
 }
@@ -231,50 +229,50 @@ static void read_long_string (LexState *ls, SemInfo *seminfo, int sep) {
     inclinenumber(ls);  /* skip it */
   for (;;) {
     switch (ls->current) {
-      case EOZ:
-        luaX_lexerror(ls, (seminfo) ? "unfinished long string" :
-                                   "unfinished long comment", TK_EOS);
-        break;  /* to avoid warnings */
+    case EOZ:
+      luaX_lexerror(ls, (seminfo) ? "unfinished long string" :
+                                    "unfinished long comment", TK_EOS);
+      break;  /* to avoid warnings */
 #if defined(LUA_COMPAT_LSTR)
-      case '[': {
-        if (skip_sep(ls) == sep) {
-          save_and_next(ls);  /* skip 2nd `[' */
-          cont++;
+    case '[': {
+      if (skip_sep(ls) == sep) {
+        save_and_next(ls);  /* skip 2nd `[' */
+        cont++;
 #if LUA_COMPAT_LSTR == 1
-          if (sep == 0)
-            luaX_lexerror(ls, "nesting of [[...]] is deprecated", '[');
+        if (sep == 0)
+          luaX_lexerror(ls, "nesting of [[...]] is deprecated", '[');
 #endif
-        }
-        break;
       }
+      break;
+    }
 #endif
-      case ']': {
-        if (skip_sep(ls) == sep) {
-          save_and_next(ls);  /* skip 2nd `]' */
+    case ']': {
+      if (skip_sep(ls) == sep) {
+        save_and_next(ls);  /* skip 2nd `]' */
 #if defined(LUA_COMPAT_LSTR) && LUA_COMPAT_LSTR == 2
-          cont--;
-          if (sep == 0 && cont >= 0) break;
+        cont--;
+        if (sep == 0 && cont >= 0) break;
 #endif
-          goto endloop;
-        }
-        break;
+        goto endloop;
       }
-      case '\n':
-      case '\r': {
-        save(ls, '\n');
-        inclinenumber(ls);
-        if (!seminfo) luaZ_resetbuffer(ls->buff);  /* avoid wasting space */
-        break;
-      }
-      default: {
-        if (seminfo) save_and_next(ls);
-        else next(ls);
-      }
+      break;
+    }
+    case '\n':
+    case '\r': {
+      save(ls, '\n');
+      inclinenumber(ls);
+      if (!seminfo) luaZ_resetbuffer(ls->buff);  /* avoid wasting space */
+      break;
+    }
+    default: {
+      if (seminfo) save_and_next(ls);
+      else next(ls);
+    }
     }
   } endloop:
-  if (seminfo)
-    seminfo->ts = luaX_newstring(ls, luaZ_buffer(ls->buff) + (2 + sep),
-                                     luaZ_bufflen(ls->buff) - 2*(2 + sep));
+    if (seminfo)
+  seminfo->ts = luaX_newstring(ls, luaZ_buffer(ls->buff) + (2 + sep),
+    luaZ_bufflen(ls->buff) - 2*(2 + sep));
 }
 
 
@@ -282,55 +280,55 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
   save_and_next(ls);
   while (ls->current != del) {
     switch (ls->current) {
-      case EOZ:
-        luaX_lexerror(ls, "unfinished string", TK_EOS);
-        continue;  /* to avoid warnings */
-      case '\n':
-      case '\r':
-        luaX_lexerror(ls, "unfinished string", TK_STRING);
-        continue;  /* to avoid warnings */
-      case '\\': {
-        int c;
-        next(ls);  /* do not save the `\' */
-        switch (ls->current) {
-          case 'a': c = '\a'; break;
-          case 'b': c = '\b'; break;
-          case 'f': c = '\f'; break;
-          case 'n': c = '\n'; break;
-          case 'r': c = '\r'; break;
-          case 't': c = '\t'; break;
-          case 'v': c = '\v'; break;
-          case '\n':  /* go through */
-          case '\r': save(ls, '\n'); inclinenumber(ls); continue;
-          case EOZ: continue;  /* will raise an error next loop */
-          default: {
-            if (!isdigit(ls->current))
-              save_and_next(ls);  /* handles \\, \", \', and \? */
-            else {  /* \xxx */
-              int i = 0;
-              c = 0;
-              do {
-                c = 10*c + (ls->current-'0');
-                next(ls);
-              } while (++i<3 && isdigit(ls->current));
-              if (c > UCHAR_MAX)
-                luaX_lexerror(ls, "escape sequence too large", TK_STRING);
-              save(ls, c);
-            }
-            continue;
-          }
+    case EOZ:
+      luaX_lexerror(ls, "unfinished string", TK_EOS);
+      continue;  /* to avoid warnings */
+    case '\n':
+    case '\r':
+      luaX_lexerror(ls, "unfinished string", TK_STRING);
+      continue;  /* to avoid warnings */
+    case '\\': {
+      int c;
+      next(ls);  /* do not save the `\' */
+      switch (ls->current) {
+      case 'a': c = '\a'; break;
+      case 'b': c = '\b'; break;
+      case 'f': c = '\f'; break;
+      case 'n': c = '\n'; break;
+      case 'r': c = '\r'; break;
+      case 't': c = '\t'; break;
+      case 'v': c = '\v'; break;
+      case '\n':  /* go through */
+      case '\r': save(ls, '\n'); inclinenumber(ls); continue;
+      case EOZ: continue;  /* will raise an error next loop */
+      default: {
+        if (!isdigit(ls->current))
+          save_and_next(ls);  /* handles \\, \", \', and \? */
+        else {  /* \xxx */
+          int i = 0;
+          c = 0;
+          do {
+            c = 10*c + (ls->current-'0');
+            next(ls);
+          } while (++i<3 && isdigit(ls->current));
+          if (c > UCHAR_MAX)
+            luaX_lexerror(ls, "escape sequence too large", TK_STRING);
+          save(ls, c);
         }
-        save(ls, c);
-        next(ls);
         continue;
       }
-      default:
-        save_and_next(ls);
+      }
+      save(ls, c);
+      next(ls);
+      continue;
+    }
+    default:
+      save_and_next(ls);
     }
   }
   save_and_next(ls);  /* skip delimiter */
   seminfo->ts = luaX_newstring(ls, luaZ_buffer(ls->buff) + 1,
-                                   luaZ_bufflen(ls->buff) - 2);
+                               luaZ_bufflen(ls->buff) - 2);
 }
 
 
@@ -338,123 +336,296 @@ static int llex (LexState *ls, SemInfo *seminfo) {
   luaZ_resetbuffer(ls->buff);
   for (;;) {
     switch (ls->current) {
-      case '\n':
-      case '\r': {
-        inclinenumber(ls);
-        continue;
-      }
-      case '-': {
-        next(ls);
-        if (ls->current != '-') return '-';
-        /* else is a comment */
-        next(ls);
-        if (ls->current == '[') {
-          int sep = skip_sep(ls);
-          luaZ_resetbuffer(ls->buff);  /* `skip_sep' may dirty the buffer */
-          if (sep >= 0) {
-            read_long_string(ls, NULL, sep);  /* long comment */
-            luaZ_resetbuffer(ls->buff);
-            continue;
-          }
-        }
-        /* else short comment */
-        while (!currIsNewline(ls) && ls->current != EOZ)
-          next(ls);
-        continue;
-      }
-      case '[': {
-        int sep = skip_sep(ls);
-        if (sep >= 0) {
-          read_long_string(ls, seminfo, sep);
-          return TK_STRING;
-        }
-        else if (sep == -1) return '[';
-        else luaX_lexerror(ls, "invalid long string delimiter", TK_STRING);
-      }
-      case '=': {
-        next(ls);
-        if (ls->current != '=') return '=';
-        else { next(ls); return TK_EQ; }
-      }
-      case '<': {
+    case '\n':
+    case '\r': {
+      inclinenumber(ls);
+      continue;
+    }
+    case '-': {
       next(ls);
-      if (ls->current == '=') { next(ls); return TK_LE; }
-        else if (ls->current == '<') { next(ls); return TK_LSHFT; }
-        else  return '<';
-      }
-      case '>': {
-        next(ls);
-        if (ls->current == '=') { next(ls); return TK_GE; }
-        else if (ls->current == '>') { next(ls); return TK_RSHFT; }
-       else return '>';
-      }
-      case '/': {
-        next(ls);
-        if (ls->current != '/') return '/';
-        else { next(ls); return TK_INTDIV; }
-      }
-      case '~': {
-        next(ls);
-        if (ls->current != '=') return '~';
-        else { next(ls); return TK_NE; }
-      }
-      case '!': {
-        next(ls);
-        if (ls->current != '=') return '!';
-        else { next(ls); return TK_NE; }
-      }
-      case '"':
-      case '\'': {
-        read_string(ls, ls->current, seminfo);
-        return TK_STRING;
-      }
-      case '.': {
-        save_and_next(ls);
-        if (check_next(ls, ".")) {
-          if (check_next(ls, "."))
-            return TK_DOTS;   /* ... */
-          else return TK_CONCAT;   /* .. */
-        }
-        else if (!isdigit(ls->current)) return '.';
-        else {
-          read_numeral(ls, seminfo);
-          return TK_NUMBER;
-        }
-      }
-      case EOZ: {
-        return TK_EOS;
-      }
-      default: {
-        if (isspace(ls->current)) {
-          lua_assert(!currIsNewline(ls));
-          next(ls);
+      if (ls->current != '-') return '-';
+      /* else is a comment */
+      next(ls);
+      if (ls->current == '[') {
+        int sep = skip_sep(ls);
+        luaZ_resetbuffer(ls->buff);  /* `skip_sep' may dirty the buffer */
+        if (sep >= 0) {
+          read_long_string(ls, NULL, sep);  /* long comment */
+          luaZ_resetbuffer(ls->buff);
           continue;
         }
-        else if (isdigit(ls->current)) {
-          read_numeral(ls, seminfo);
-          return TK_NUMBER;
-        }
-        else if (isalpha(ls->current) || ls->current == '_') {
-          /* identifier or reserved word */
-          TString *ts;
-          do {
-            save_and_next(ls);
-          } while (isalnum(ls->current) || ls->current == '_');
-          ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
-                                  luaZ_bufflen(ls->buff));
-          if (ts->tsv.reserved > 0)  /* reserved word? */
-            return ts->tsv.reserved - 1 + FIRST_RESERVED;
-          else {
-            seminfo->ts = ts;
-            return TK_NAME;
-          }
-        }
-        else {
-          int c = ls->current;
-          next(ls);
-          return c;  /* single-char tokens (+ - / ...) */
-        }
       }
+      /* else short comment */
+      while (!currIsNewline(ls) && ls->current != EOZ)
+        next(ls);
+      continue;
+    }
+    case '[': {
+      int sep = skip_sep(ls);
+      if (sep >= 0) {
+        read_long_string(ls, seminfo, sep);
+        return TK_STRING;
+      }
+      else if (sep == -1) return '[';
+      else luaX_lexerror(ls, "invalid long string delimiter", TK_STRING);
+    }
+    case '=': {
+      next(ls);
+      if (ls->current != '=') return '=';
+      else { next(ls); return TK_EQ; }
+    }
+    case '<': {
+      next(ls);
+      if (ls->current == '=') { next(ls); return TK_LE; }
+      else if (ls->current == '<') { next(ls); return TK_LSHFT; }
+      else  return '<';
+    }
+    case '>': {
+      next(ls);
+      if (ls->current == '=') { next(ls); return TK_GE; }
+      else if (ls->current == '>') { next(ls); return TK_RSHFT; }
+      else return '>';
+    }
+    case '/': {
+      next(ls);
+      if (ls->current != '/') return '/';
+      else { next(ls); return TK_INTDIV; }
+    }
+    case '~': {
+      next(ls);
+      if (ls->current != '=') return '~';
+      else { next(ls); return TK_NE; }
+    }
+    case '!': {
+      luaX_lexerror(ls, "assembler support is not implemented yet", 0);
+    }
+    case '"':
+    case '\'': {
+      read_string(ls, ls->current, seminfo);
+      return TK_STRING;
+    }
+    case '.': {
+      save_and_next(ls);
+      if (check_next(ls, ".")) {
+        if (check_next(ls, "."))
+          return TK_DOTS;   /* ... */
+        else return TK_CONCAT;   /* .. */
+      }
+      else if (!isdigit(ls->current)) return '.';
+      else {
+        read_numeral(ls, seminfo);
+        return TK_NUMBER;
+      }
+    }
+    case '@': {
+      luaX_lexerror(ls, "invalid macro identifier", 0);
+    }
+    case EOZ: {
+      return TK_EOS;
+    }
+    default: {
+      if (isspace(ls->current)) {
+        lua_assert(!currIsNewline(ls));
+        next(ls);
+        continue;
+      }
+      else if (isdigit(ls->current)) {
+        read_numeral(ls, seminfo);
+        return TK_NUMBER;
+      }
+      else if (isalpha(ls->current) || ls->current == '_') {
+        TString *ts;
+        do {
+          save_and_next(ls);
+        } while (isalnum(ls->current) || ls->current == '_');
+        ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
+                            luaZ_bufflen(ls->buff));
+        while (isspace(ls->current)) {
+          if (ls->current == '\n') ++ls->linenumber;
+          next(ls);
+        }
+        if (ls->current == '@') {
+          if (ts->tsv.reserved > 0)
+            luaX_lexerror(ls, "invalid macro identifier",
+                          ts->tsv.reserved - 1 + FIRST_RESERVED);
+          lua_State *L = ls->L;
+          lua_getglobal(L, MACRO);
+
+          if(!lua_istable(L,-1))
+          {
+            lua_pop(L, 1);
+            lua_newtable(L);
+            lua_setglobal(L, MACRO);
+            lua_getglobal(L, MACRO);
+          }
+          next(ls);
+          save(ls, '\0');
+          char *key = malloc(strlen(ls->buff->buffer) + 1);
+          if (key) strcpy(key, ls->buff->buffer);
+          else luaX_lexerror(ls, "cannot allocate enough memory",0);
+          lua_pushstring(L, key);
+          lua_gettable(L, -2);
+          if (!lua_isnil(L, -1))
+          {
+            if (ls->current != '@')
+              luaX_lexerror(ls, "definition of existent macro", 0);
+          } else if (ls->current == '@')
+            luaX_lexerror(ls, "redefinition of nonexistent macro", 0);
+          if (ls->current == '@') next(ls);
+          lua_pop(L, 1);
+          lua_pushstring(L, key);
+          luaZ_resetbuffer(ls->buff);
+          while (isspace(ls->current))
+          {
+            if (ls->current == '\n') ++ls->linenumber;
+            next(ls);
+          }
+          char q = ls->current;
+          switch (q)
+          {
+          case '\'':
+          case '"':
+          {
+            save_and_next(ls);
+            while (ls->current != q)
+            {
+              if (ls->current == EOZ)
+                luaX_lexerror(ls, "unfinished string at macro definition", 0);
+              if (ls->current == '\n')
+                luaX_lexerror(ls, "unfinished string at macro definition", TK_STRING);
+              save_and_next(ls);
+            }
+            save_and_next(ls);
+            break;
+          }
+          case '[':
+          {
+            save_and_next(ls);
+            if (ls->current != '[' && ls->current != '=')
+              luaX_lexerror(ls, "invalid long string at macro definition", 0);
+            int eqlen = 0;
+            int eqnum = 0;
+            while (ls->current == '=') {eqlen++; save_and_next(ls);};
+            if (eqlen > 0 && ls->current != '[')
+              luaX_lexerror(ls, "invalid long string at macro definition", 0);
+            save_and_next(ls);
+            for(;;)
+            {
+              switch (ls->current)
+              {
+              case EOZ:
+                luaX_lexerror(ls, "unfinished long string at macro definition", 0);
+                break;
+              case '\n':
+                ls->linenumber++;
+                break;
+              case '=':
+                ++eqnum;
+                break;
+              case ']':
+                if (eqnum == -1) eqnum = 0;
+              }
+              if (ls->current != '=' && ls->current != ']') eqnum = -1;
+              save_and_next(ls);
+              if (eqnum == eqlen && ls->current == ']')
+              {
+                save_and_next(ls);
+                break;
+              }
+            }
+            break;
+          }
+          case '-': case '0': case '1': case '2': case '3': case '4':
+          case '.': case '5': case '6': case '7': case '8': case '9':
+          {
+            while (!isspace(ls->current)) save_and_next(ls);
+            break;
+          }
+          case '`': case '~': case '!': case '#': case '$': case '%': case '^':
+          case '&': case '*': case '/': case '+': case '=': case '|': case '\\':
+          {
+            next(ls);
+            while (ls->current != q)
+            {
+              if (ls->current == EOZ)
+                luaX_lexerror(ls, "unfinished macro definition", 0);
+              if (ls->current == '\n') ++ls->linenumber;
+              save_and_next(ls);
+            }
+            next(ls);
+            break;
+          }
+          default:
+          {
+            if (isalpha(ls->current) || ls->current == '_') {
+              do {
+                save_and_next(ls);
+              } while (isalnum(ls->current) || ls->current == '_');
+            } else luaX_lexerror(ls, "invalid macro marker", 0);
+          }
+          }
+          save(ls, ' ');
+          save(ls, '\0');
+          char *val = malloc(strlen(ls->buff->buffer) + 1);
+          if(val) strcpy(val, ls->buff->buffer);
+          lua_pushstring(L, val);
+          luaZ_resetbuffer(ls->buff);
+          lua_rawset(L, -3);
+          lua_setglobal(L, MACRO);
+          free(key);
+          free(val);
+          continue;
+        }
+        if (ts->tsv.reserved > 0)  /* reserved word? */
+          return ts->tsv.reserved - 1 + FIRST_RESERVED;
+        lua_State *L = ls->L;
+        lua_getglobal(L, MACRO);
+        if (lua_istable(L, -1)) {
+          save(ls, '\0');
+          char *k = ls->buff->buffer;
+          lua_getfield(L, -1, k);
+          if (lua_isstring(L, -1)) {
+            luaZ_resetbuffer(ls->buff);
+            char *s = lua_tostring(L, -1);
+            if (ls->mpos < ls->mlen) {
+              int len = strlen(s) + ls->mlen - ls->mpos + 1;
+              char *res = (char*) malloc(len);
+              strcpy(res, s);
+              strcat(res, &ls->mstr[ls->mpos-1]);
+              strcat(res, " ");
+              free(ls->mstr);
+              free(s);
+              ls->mstr = res;
+              ls->z->n--; ls->z->p++;
+            }
+            else {
+              if (ls->mlen > 0) free(ls->mstr);
+              ls->mstr = s;
+            }
+            ls->mpos = 1;
+            ls->mlen = strlen(ls->mstr);
+            if (ls->mlen > 0) {
+              ls->current = ls->mstr[0];
+              ls->z->n++; ls->z->p--;
+            }
+            lua_pop(L, 1);
+            lua_pop(L, 1);
+            if (ls->mswt++ > 1e6) luaX_lexerror(ls, "possible mutual macro recursion", 0);
+            continue;
+          }
+          lua_pop(L, 1);
+        }
+        lua_pop(L, 1);
+
+        seminfo->ts = ts;
+        return TK_NAME;
+      }
+      else {
+        int c = ls->current;
+        next(ls);
+        return c;  /* single-char tokens (+ - / ...) */
+      }
+    }
     }
   }
 }

--- a/lua514u/src/llex.h
+++ b/lua514u/src/llex.h
@@ -28,7 +28,7 @@ enum RESERVED {
   TK_IF, TK_IN, TK_LOCAL, TK_NIL, TK_NOT, TK_OR, TK_REPEAT,
   TK_RETURN, TK_THEN, TK_TRUE, TK_UNTIL, TK_WHILE,
   /* other terminal symbols */
-  TK_CONCAT, TK_DOTS, TK_EQ, TK_GE, TK_LE, TK_NE, TK_CNE,
+  TK_CONCAT, TK_DOTS, TK_EQ, TK_GE, TK_LE, TK_NE,
   TK_LSHFT, TK_RSHFT, TK_INTDIV,
   TK_NUMBER, TK_NAME, TK_STRING, TK_EOS
 };
@@ -65,6 +65,10 @@ typedef struct LexState {
   Mbuffer *buff;  /* buffer for tokens */
   TString *source;  /* current source name */
   char decpoint;  /* locale decimal point */
+  char *mstr; /* macro string */
+  int mpos; /* current character position of macro string */
+  int mlen; /* macro string length */
+  int mswt; /* number of switches between source and macro */
 } LexState;
 
 

--- a/lua514u/src/lparser.c
+++ b/lua514u/src/lparser.c
@@ -383,6 +383,10 @@ static void close_func (LexState *ls) {
 Proto *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff, const char *name) {
   struct LexState lexstate;
   struct FuncState funcstate;
+  lexstate.mstr = "";
+  lexstate.mpos = 0;
+  lexstate.mlen = 0;
+  lexstate.mswt = 0;
   lexstate.buff = buff;
   luaX_setinput(L, &lexstate, z, luaS_new(L, name));
   open_func(&lexstate, &funcstate);


### PR DESCRIPTION
Short macro syntax:
`x @ id`
`x @ "string"`
`x @ 'string'`
`x @ [[long string]]`
`x @ -123.4`
Long macro syntax:
`x @ |any_code|`
Where you can use in place of `|` pair any pair of the following markers to define macro body:
`\ ``` ~ ! # $ % ^ & * / + = | \`