### PR TITLE
Shader leak fix 20160901

### DIFF
--- a/2dsg/gfxbackends/Shaders.cpp
+++ b/2dsg/gfxbackends/Shaders.cpp
@@ -67,6 +67,12 @@ bool ShaderProgram::updateConstant(int index,ShaderProgram::ConstantType type, i
 	case CFLOAT:
 		sl=4;
 		break;
+	case CFLOAT2:
+		sl=8;
+		break;
+	case CFLOAT3:
+		sl=12;
+		break;
 	case CFLOAT4:
 		sl=16;
 		break;

--- a/luabinding/meshbinder.cpp
+++ b/luabinding/meshbinder.cpp
@@ -338,7 +338,7 @@ int MeshBinder::setGenericArray(lua_State *L)
     	lua_error(L);
     }
 
-    void *ptr;
+    void *ptr = 0;
 	switch (type)
 	{
 	case ShaderProgram::DBYTE:
@@ -390,6 +390,7 @@ int MeshBinder::setGenericArray(lua_State *L)
 	}
 
     mesh->setGenericArray(index,ptr,type,mult,count);
+	free(ptr);
 	return 0;
 }
 


### PR DESCRIPTION
Memory leaks in MeshBinder::setGenericArray() and accept FLOAT2, FLOAT3 types in ShaderProgram::updateConstant.