### PR TITLE
Add  scale mode options for splash image

### DIFF
--- a/gdrexport/ExportCommon.h
+++ b/gdrexport/ExportCommon.h
@@ -19,7 +19,7 @@ public:
 	static void exportLuafilesTxt(ExportContext *ctx);
 	static void exportAllfilesTxt(ExportContext *ctx);
 	static bool applyPlugins(ExportContext *ctx);
-    static void resizeImage(QImage *image, int width, int height, QString output, int quality = -1,bool withAlpha=true,QColor fill=QColor("transparent"));
+    static void resizeImage(QImage *image, int width, int height, QString output, int quality = -1,bool withAlpha=true,QColor fill=QColor("transparent"), int mode = 0);
 	static bool appIcon(ExportContext *ctx,int width,int height,QString output,bool withAlpha=true);
     static bool tvIcon(ExportContext *ctx, int width, int height, QString output,bool withAlpha=true);
     static bool splashHImage(ExportContext *ctx, int width, int height, QString output,bool withAlpha=true);

--- a/ui/librarytreewidget.cpp
+++ b/ui/librarytreewidget.cpp
@@ -18,6 +18,8 @@
 
 #include "addnewfiledialog.h"
 #include "projectpropertiesdialog.h"
+#include "qtutils.h"
+
 
 LibraryTreeWidget::LibraryTreeWidget(QWidget *parent)
 	: QTreeWidget(parent)
@@ -73,6 +75,14 @@ LibraryTreeWidget::LibraryTreeWidget(QWidget *parent)
     excludeFromExecutionAction_->setCheckable(true);
     connect(excludeFromExecutionAction_, SIGNAL(triggered(bool)), this, SLOT(excludeFromExecution(bool)));
 
+#if defined(Q_OS_WIN)
+    showInFindeAction_ = new QAction(tr("Show in Explorer"), this);
+#else
+    showInFindeAction_ = new QAction(tr("Show in Finder"), this);
+#endif
+
+    connect(showInFindeAction_, SIGNAL(triggered()), this, SLOT(showInFinder()));
+
     setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(this, SIGNAL(customContextMenuRequested  (const QPoint&)),
 			this, SLOT  (onCustomContextMenuRequested(const QPoint&)));
@@ -123,6 +133,13 @@ void LibraryTreeWidget::onCustomContextMenuRequested(const QPoint& pos)
 		}
 	}
 
+    //add "show in finder" in the first position just as Xcode did
+#if defined(Q_OS_MAC)   //only for Mac since I have not tested on Windows yet, after tested, this macro may safely removed.
+    if (size == 1 && file)
+    {
+        menu.addAction(showInFindeAction_);
+    }
+#endif
 	if (size == 1 && (folder || project))
 	{
 		menu.addAction(addNewFileAction_);
@@ -215,6 +232,23 @@ void LibraryTreeWidget::newFont()
 }
 */
 
+
+void LibraryTreeWidget::showInFinder()
+{
+    if (selectedItems().empty() == true)
+        return;
+
+    QTreeWidgetItem* item = selectedItems()[0];
+
+    QString fileName = item->data(0, Qt::UserRole).toMap()["filename"].toString();
+
+    QDir dir = QFileInfo(projectFileName_).dir();
+
+    QString path = QDir::cleanPath(dir.absoluteFilePath(fileName));
+
+    doShowInFinder(path);
+}
+
 void LibraryTreeWidget::remove()
 {
 	QList<QTreeWidgetItem*> selectedItems = this->selectedItems();
@@ -256,6 +290,7 @@ void LibraryTreeWidget::remove()
 
 	checkModification();
 }
+
 
 void LibraryTreeWidget::rename()
 {

--- a/ui/librarytreewidget.cpp
+++ b/ui/librarytreewidget.cpp
@@ -134,12 +134,11 @@ void LibraryTreeWidget::onCustomContextMenuRequested(const QPoint& pos)
 	}
 
     //add "show in finder" in the first position just as Xcode did
-#if defined(Q_OS_MAC)   //only for Mac since I have not tested on Windows yet, after tested, this macro may safely removed.
     if (size == 1 && file)
     {
         menu.addAction(showInFindeAction_);
     }
-#endif
+
 	if (size == 1 && (folder || project))
 	{
 		menu.addAction(addNewFileAction_);

--- a/ui/librarytreewidget.h
+++ b/ui/librarytreewidget.h
@@ -65,7 +65,7 @@ private slots:
 	void projectProperties();
     void automaticDownsizing(bool checked);
     void excludeFromExecution(bool checked);
-
+    void showInFinder();
 private slots:
 	void checkModification();
 
@@ -87,7 +87,7 @@ private:
 	QAction* projectPropertiesAction_;
 	QAction* automaticDownsizingAction_;
     QAction* excludeFromExecutionAction_;
-
+    QAction* showInFindeAction_;
 private:
 	QString xmlString_;
 	bool isModifed_;

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -2363,7 +2363,6 @@ void MainWindow::exportProject()
         QString templatename;
         QString templatenamews;
 
-
         if (exportType=="iOS")
         {
             arguments << "-platform" << "ios";
@@ -2428,9 +2427,11 @@ void MainWindow::exportProject()
         }
 
 
-
         QDir dir2 = QDir::currentPath();
-        dir2.cd("Templates");
+        if(!dir2.cd("Templates")){
+            QMessageBox::information(this, tr("Gideros"), tr("No Templates folder."));
+            return;
+        }
         if(!dir2.cd(templatedir) || !dir2.cd(templatename)){
             QMessageBox::information(this, tr("Gideros"), tr("No template found."));
             return;

--- a/ui/projectproperties.cpp
+++ b/ui/projectproperties.cpp
@@ -62,6 +62,8 @@ void ProjectProperties::toXml(QDomDocument doc,QDomElement properties) const
     properties.setAttribute("splash_v_image", this->splash_v_image);
     properties.setAttribute("app_name", this->app_name);
 
+    properties.setAttribute("splashScaleMode", this->splashScaleMode);
+
     //Plugins
 	QDomElement plugins = doc.createElement("plugins");
 	for (QSet<Plugin>::const_iterator it=this->plugins.begin();it!=this->plugins.end(); it++)
@@ -198,6 +200,8 @@ void ProjectProperties::loadXml(QDomElement properties)
             this->disableSplash = properties.attribute("disableSplash").toInt() != 0;
         if(!properties.attribute("backgroundColor").isEmpty())
             this->backgroundColor = properties.attribute("backgroundColor");
+        if (!properties.attribute("splashScaleMode").isEmpty())
+            this->splashScaleMode = properties.attribute("splashScaleMode").toInt();
 
         //Plugins
         this->plugins.clear();

--- a/ui/projectproperties.h
+++ b/ui/projectproperties.h
@@ -79,6 +79,7 @@ struct ProjectProperties
         splash_v_image="";
         disableSplash = false;
         backgroundColor = "#ffffff";
+        splashScaleMode = 0;
         plugins.clear();
         exports.clear();
     }
@@ -133,6 +134,7 @@ struct ProjectProperties
     QSet<Export> exports;
     bool encryptCode;
     bool encryptAssets;
+    int splashScaleMode;
 };
 
 inline bool operator==(const ProjectProperties::Plugin &p1, const ProjectProperties::Plugin &p2) { return (p1.name==p2.name)&&(p1.properties==p2.properties); };

--- a/ui/projectpropertiesdialog.cpp
+++ b/ui/projectpropertiesdialog.cpp
@@ -72,6 +72,8 @@ ProjectPropertiesDialog::ProjectPropertiesDialog(QString projectFileName,Project
     ui->backgroundColor->setAutoFillBackground(true);
     ui->backgroundColor->setFlat(true);
 
+    ui->splashScaleMode->setCurrentIndex(properties_->splashScaleMode);
+
     connect(ui->add, SIGNAL(clicked()), this, SLOT(add()));
 	connect(ui->remove, SIGNAL(clicked()), this, SLOT(remove()));
 
@@ -160,6 +162,8 @@ void ProjectPropertiesDialog::onAccepted()
 
     properties_->disableSplash = ui->disableSplash->isChecked();
     properties_->backgroundColor = this->backgroundColor.name();
+
+    properties_->splashScaleMode = ui->splashScaleMode->currentIndex();
 
 }
 

--- a/ui/projectpropertiesdialog.ui
+++ b/ui/projectpropertiesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>415</width>
-    <height>544</height>
+    <width>482</width>
+    <height>558</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -869,7 +869,7 @@ portrait or landscape.</string>
         <rect>
          <x>10</x>
          <y>0</y>
-         <width>121</width>
+         <width>171</width>
          <height>351</height>
         </rect>
        </property>
@@ -981,7 +981,7 @@ portrait or landscape.</string>
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>360</y>
+         <y>390</y>
          <width>361</width>
          <height>80</height>
         </rect>
@@ -1002,6 +1002,39 @@ portrait or landscape.</string>
          </widget>
         </item>
        </layout>
+      </widget>
+      <widget class="QComboBox" name="splashScaleMode">
+       <property name="geometry">
+        <rect>
+         <x>160</x>
+         <y>350</y>
+         <width>131</width>
+         <height>31</height>
+        </rect>
+       </property>
+       <item>
+        <property name="text">
+         <string>Show All</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Crop</string>
+        </property>
+       </item>
+      </widget>
+      <widget class="QLabel" name="label_13">
+       <property name="geometry">
+        <rect>
+         <x>9</x>
+         <y>360</y>
+         <width>121</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Splash Scale Mode:</string>
+       </property>
       </widget>
      </widget>
     </widget>

--- a/ui/qtutils.cpp
+++ b/ui/qtutils.cpp
@@ -7,11 +7,13 @@
 void doShowInFinder(const QString& path){
 #if defined(Q_OS_WIN)
     const QString explorer = "explorer";
-        QStringList param;
+        QString param;
         if (!QFileInfo(path).isDir())
-            param << QLatin1String("/select,");
-        param << QDir::toNativeSeparators(path);
-        QProcess::startDetached(explorer, param);
+            param = QLatin1String("/select,");
+        param += QDir::toNativeSeparators(path);
+        QString command = explorer + " " + param;
+        QProcess::startDetached(command);
+
 #elif defined(Q_OS_MAC)
     QStringList scriptArgs;
         scriptArgs << QLatin1String("-e")

--- a/ui/qtutils.cpp
+++ b/ui/qtutils.cpp
@@ -1,0 +1,26 @@
+#include "qtutils.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QProcess>
+
+void doShowInFinder(const QString& path){
+#if defined(Q_OS_WIN)
+    const QString explorer = "explorer";
+        QStringList param;
+        if (!QFileInfo(path).isDir())
+            param << QLatin1String("/select,");
+        param << QDir::toNativeSeparators(path);
+        QProcess::startDetached(explorer, param);
+#elif defined(Q_OS_MAC)
+    QStringList scriptArgs;
+        scriptArgs << QLatin1String("-e")
+                   << QString::fromLatin1("tell application \"Finder\" to reveal POSIX file \"%1\"")
+                                         .arg(path);
+        QProcess::execute(QLatin1String("/usr/bin/osascript"), scriptArgs);
+        scriptArgs.clear();
+        scriptArgs << QLatin1String("-e")
+                   << QLatin1String("tell application \"Finder\" to activate");
+        QProcess::execute("/usr/bin/osascript", scriptArgs);
+#endif
+}

--- a/ui/qtutils.h
+++ b/ui/qtutils.h
@@ -1,0 +1,10 @@
+#ifndef QTUTILS_H
+#define QTUTILS_H
+
+#include <QString>
+
+
+void doShowInFinder(const QString& path);
+
+
+#endif // QTUTILS_H

--- a/ui/ui.pro
+++ b/ui/ui.pro
@@ -81,7 +81,8 @@ SOURCES += \
     propertyeditingtable.cpp \
     mdiarea.cpp \
     mdisubwindow.cpp \
-    dependencygraph.cpp
+    dependencygraph.cpp \
+    qtutils.cpp
 
 SOURCES += $$files(../libpvrt/*.cpp)
 
@@ -119,7 +120,8 @@ HEADERS  += \
     mdiarea.h \
     mdisubwindow.h \
     pluginschooser.h \
-    dependencygraph.h
+    dependencygraph.h \
+    qtutils.h
 
 FORMS    += mainwindow.ui \
     savechangesdialog.ui \


### PR DESCRIPTION
Currently, option show all will keep all the contents of the original
image and may fill the margin with background color
Option Crop will fill the whole screen and some contents may be cropped.
Both options preserving the aspect ratio.