### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ stage:addChild(shape)
 * [**Developer Center:**](http://giderosmobile.com/DevCenter/index.php/Main_Page) Developer Center contains different articles and posts about Gideros, that might help you deal with some specific problems.
 * [**Everything else...**](http://giderosmobile.com/guide) All developer related documentation... 
 
-##3rd party tools 
+## 3rd party tools 
 
 Gideros runs with many 3rd party applications, from Particle Candy to Physics Editor to Texture Packer. [Here'a an incomplete list](http://giderosmobile.com/tools).
 

--- a/external/liquidfun-1.0.0/liquidfun/Box2D/Box2D/Documentation/Programmers-Guide/Chapter11_Particles.md
+++ b/external/liquidfun-1.0.0/liquidfun/Box2D/Box2D/Documentation/Programmers-Guide/Chapter11_Particles.md
@@ -289,7 +289,7 @@ particles.
 For a group of particles, use the `b2ParticleGroupFlag` enum, which provides
 two types of particle groups:
 
-###Solid
+### Solid
 
 A solid particle group prevents other bodies from lodging inside of it. Should
 anything penetrate it, the solid particle group pushes the offending body back
@@ -306,7 +306,7 @@ specify a solid particle group. For example:
 
 &nbsp;&nbsp;&nbsp;`pd.groupFlags = b2_solidParticleGroup;`
 
-###Rigid
+### Rigid
 
 Rigid particle groups are ones whose shape does not change, even when they
 collide


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
