### PR TITLE
[github] improve tab formatting on some browsers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+[*.{h,c,hpp,cpp}]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Re tabs vs spaces, I discovered that adding an .editorconfig file would stop GitHub using stupid 8 space tabs on some browsers. It doesn't work on Microsoft Edge or Internet Explorer, but works here on Firefox.

Here's a gideros repo file (without .editorconfig yet)...

https://github.com/gideros/gideros/blob/master/luabinding/box2dbinder2.cpp

... and here's the same file in my fork...

https://github.com/paul-reilly/gideros/blob/master/luabinding/box2dbinder2.cpp
