### PR TITLE
fix a no response issue when unlock the screen

### DIFF
--- a/android/GiderosAndroidPlayer/src/com/giderosmobile/android/player/GiderosApplication.java
+++ b/android/GiderosAndroidPlayer/src/com/giderosmobile/android/player/GiderosApplication.java
@@ -543,7 +543,8 @@ public class GiderosApplication
 			synchronized (eventQueue_) {
 				eventQueue_.add(PAUSE);
 				try {
-					eventQueue_.wait();
+					//on some devices, onDrawFrame will not called when screen locked,this thread will not wake up
+					eventQueue_.wait(100);
 				} catch (InterruptedException e) {
 				}
 			}
@@ -587,7 +588,8 @@ public class GiderosApplication
 			synchronized (eventQueue_) {
 				eventQueue_.add(RESUME);
 				try {
-					eventQueue_.wait();
+					//on some devices, onDrawFrame will not called when screen locked,this thread will not wake up
+					eventQueue_.wait(100);
 				} catch (InterruptedException e) {
 				}
 			}


### PR DESCRIPTION
On some device, lock the screen when the gam is running will cause the game freeze after unlock the screen.