### PR TITLE
[binder] Fix 'nullptr not declared...' build errors

### DIFF
--- a/luabinding/binder.cpp
+++ b/luabinding/binder.cpp
@@ -28,8 +28,8 @@ void Binder::createClass(std::string classname,
                          int (*destructor) (lua_State*),
                          std::vector<luaL_Reg> functionlist)
 {
-    const char* _class = classname == "" ? nullptr : classname.c_str();
-    const char* _base = basename == "" ? nullptr : basename.c_str();
+    const char* _class = classname == "" ? NULL : classname.c_str();
+    const char* _base = basename == "" ? NULL : basename.c_str();
     g_createClass(L, _class, _base, constructor, destructor, static_cast<luaL_Reg*>(functionlist.data()));
 }
 


### PR DESCRIPTION
This error was the reason for me adding the C++ exclusive include paths in the win32 Makefile. But on further testing it's affecting other win32 build scripts so changing to NULL fixes it.