### PR TITLE
[html5] Fix background colour on export splash screen

### DIFF
--- a/gdrexport/ExportBuiltin.cpp
+++ b/gdrexport/ExportBuiltin.cpp
@@ -141,7 +141,7 @@ void ExportBuiltin::fillTargetReplacements(ExportContext *ctx)
     }
     else if(ctx->deviceFamily == e_Html5){
         replaceList1 << qMakePair(QString("<title>Gideros</title>").toUtf8(), ("<title>"+ctx->appName+"</title>").toUtf8());
-        replaceList1 << qMakePair(QString("<body class=\"fullscreen\">").toUtf8(), ("<body class=\"fullscreen\" style=\"background-color:"+ctx->properties.backgroundColor+";\">").toUtf8());
+        replaceList1 << qMakePair(QString("<body class=\"fullscreen toplevel\">").toUtf8(), ("<body class=\"fullscreen toplevel\" style=\"background-color:"+ctx->properties.backgroundColor+";\">").toUtf8());
         if(ctx->properties.disableSplash)
             replaceList1 << qMakePair(QString("<img src=\"gideros.png\" />").toUtf8(), QString("<img src=\"gideros.png\" style=\"display:none;\"/>").toUtf8());
         if (!ctx->player)


### PR DESCRIPTION
I think this addresses #395. On export now with the optional splash screen disabled now the colour selected in Project Properties is full screen.