### PR TITLE
[plugin/threads] Add configurable exit delay

### DIFF
--- a/plugins/threads/source/luathread.h
+++ b/plugins/threads/source/luathread.h
@@ -61,6 +61,9 @@ class LuaThread
     int getResult(lua_State* L);
     static int lua_getResult(lua_State* L);
 
+    // set time for main thread to wait for thread to exit
+    static int lua_setExitWaitTime(lua_State* L);
+
     bool hasTerminationBeenRequested();
     // sets atomic variable for thread state to check via lua_thread_shouldTerminate
     static int lua_requestTermination(lua_State* L);
@@ -100,6 +103,7 @@ class LuaThread
     std::mutex m_mutex;
 
   public:
+    int m_exit_wait_time;
     ThreadTimedLuaHook m_thread_timed_lua_hook;
     static void* alloc(void *ud, void *ptr, size_t osize, size_t nsize);
     static int lua_create(lua_State *L);

--- a/plugins/threads/source/threads_entry.cpp
+++ b/plugins/threads/source/threads_entry.cpp
@@ -28,6 +28,7 @@ static int loader(lua_State *L) {
             { "requestTermination",       LuaThread::lua_requestTermination },
             { "getResult",                LuaThread::lua_getResult },
             { "fetchData",                LuaThread::lua_fetchData },
+            { "setExitWaitTime",          LuaThread::lua_setExitWaitTime },
             { nullptr,                    nullptr }
         }
     );


### PR DESCRIPTION
This allows the user to set the time to wait for the thread to exit, so solves the crash when restarting problem.