### PR TITLE
Update MetroDark.qss

### DIFF
--- a/ui/Resources/Themes/MetroDark.qss
+++ b/ui/Resources/Themes/MetroDark.qss
@@ -458,7 +458,8 @@ QTabBar::tab:disabled {
 
 QTabBar::tab:selected {
   color: #d8d8d8;
-  background-color: #2d2d2d;
+  /* background-color: #2d2d2d; */
+  background-color: #D94D1A;
 }
 
 QTabBar::tab:top {


### PR DESCRIPTION
@hgy29 I am proposing to change the selected tab color in the metrodark.qss theme.
Right now the selected tab color is the same as the other tabs (non-selected tabs).
To make the active tab more visible I am proposing to change its color to an orangy color. You can put the color you prefer.
Thank you.