### PR TITLE
little typo was causing an error

### DIFF
--- a/samplecode-bleedingedge/Scene Manager/scenemanager.lua
+++ b/samplecode-bleedingedge/Scene Manager/scenemanager.lua
@@ -169,7 +169,7 @@ function SceneManager.fade(scene1, scene2, t)
 	end
 end
 
-function SceneManager.crossfade(scene1, scene2, t)
+function SceneManager.crossFade(scene1, scene2, t)
 	scene1:setAlpha(1 - t)
 	scene2:setAlpha(t)
 end


### PR DESCRIPTION
little typo was causing an error when trying to call crossFade transition in the main.lua file
local transitions = {
	SceneManager.moveFromLeft,
	SceneManager.moveFromRight,
	SceneManager.moveFromBottom,
	SceneManager.moveFromTop,
	SceneManager.moveFromLeftWithFade,
	SceneManager.moveFromRightWithFade,
	SceneManager.moveFromBottomWithFade,
	SceneManager.moveFromTopWithFade,
	SceneManager.overFromLeft,
	SceneManager.overFromRight,
	SceneManager.overFromBottom,
	SceneManager.overFromTop,
	SceneManager.overFromLeftWithFade,
	SceneManager.overFromRightWithFade,
	SceneManager.overFromBottomWithFade,
	SceneManager.overFromTopWithFade,
	SceneManager.fade,
	SceneManager.crossFade,
	SceneManager.flip,
	SceneManager.flipWithFade,
	SceneManager.flipWithShade,
}