### PR TITLE
Update imgui_bindings.cpp

### DIFF
--- a/plugins/imgui/source/Common/imgui_bindings.cpp
+++ b/plugins/imgui/source/Common/imgui_bindings.cpp
@@ -3081,7 +3081,7 @@ int DragInt2(lua_State* L)
     const char* format = luaL_optstring(L, 8, "%d");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, 0);
 
-    bool result = ImGui::DragInt(label, vec2i, v_speed, v_min, v_max, format, sliderFlag);
+    bool result = ImGui::DragInt2(label, vec2i, v_speed, v_min, v_max, format, sliderFlag);
 
     lua_pushinteger(L, vec2i[0]);
     lua_pushinteger(L, vec2i[1]);
@@ -3103,7 +3103,7 @@ int DragInt3(lua_State* L)
     const char* format = luaL_optstring(L, 8, "%d");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, 0);
 
-    bool result = ImGui::DragInt(label, vec3i, v_speed, v_min, v_max, format, sliderFlag);
+    bool result = ImGui::DragInt3(label, vec3i, v_speed, v_min, v_max, format, sliderFlag);
 
     lua_pushinteger(L, vec3i[0]);
     lua_pushinteger(L, vec3i[1]);
@@ -3127,7 +3127,7 @@ int DragInt4(lua_State* L)
     const char* format = luaL_optstring(L, 10, "%d");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 11, 0);
 
-    bool result = ImGui::DragInt(label, vec4i, v_speed, v_min, v_max, format, sliderFlag);
+    bool result = ImGui::DragInt4(label, vec4i, v_speed, v_min, v_max, format, sliderFlag);
 
     lua_pushinteger(L, vec4i[0]);
     lua_pushinteger(L, vec4i[1]);
@@ -3143,8 +3143,8 @@ int DragIntRange2(lua_State* L)
     int v_current_min = luaL_checkinteger(L, 3);
     int v_current_max = luaL_checkinteger(L, 4);
     double v_speed = luaL_optnumber(L, 5, 1.0f);
-    int v_min = luaL_optinteger(L, 6, 0.0f);
-    int v_max = luaL_optinteger(L, 7, 0.0f);
+    int v_min = luaL_optinteger(L, 6, 0);
+    int v_max = luaL_optinteger(L, 7, 0);
     const char* format = luaL_optstring(L, 8, "%d");
     const char* format_max = luaL_optstring(L, 9, NULL);
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 10, 0);
@@ -3163,9 +3163,9 @@ int DragScalar(lua_State* L)
     ImGuiDataType data_type = luaL_checkinteger(L, 3);
     double value = luaL_checknumber(L, 4);
     double v_speed = luaL_checknumber(L, 5);
-    double v_min = luaL_optnumber(L, 6, NULL);
-    double v_max = luaL_optnumber(L, 7, NULL);
-    const char* format = luaL_optstring(L, 8, NULL);
+    double v_min = luaL_optnumber(L, 6, 0.0f);
+    double v_max = luaL_optnumber(L, 7, 0.0f);
+    const char* format = luaL_optstring(L, 8, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, 0);
 
     bool result = ImGui::DragScalar(label, data_type, (void *)&value, v_speed, (void *)&v_min, (void *)&v_max, format, sliderFlag);
@@ -3185,8 +3185,8 @@ int SliderFloat(lua_State* L)
 {
     const char* label = luaL_checkstring(L, 2);
     float v = luaL_checknumber(L, 3);
-    float v_min = luaL_checknumber(L, 4);
-    float v_max = luaL_checknumber(L, 5);
+    float v_min = luaL_optnumber(L, 4, 0.0f);
+    float v_max = luaL_optnumber(L, 5, 0.0f);
     const char* format = luaL_optstring(L, 6, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 7, 0);
 
@@ -3203,8 +3203,8 @@ int SliderFloat2(lua_State* L)
     float vec2f[2];
     vec2f[0] = luaL_checknumber(L, 3);
     vec2f[1] = luaL_checknumber(L, 4);
-    float v_min = luaL_checknumber(L, 5);
-    float v_max = luaL_checknumber(L, 6);
+    float v_min = luaL_optnumber(L, 5, 0.0f);
+    float v_max = luaL_optnumber(L, 6, 0.0f);
     const char* format = luaL_optstring(L, 7, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 8, 0);
 
@@ -3223,16 +3223,16 @@ int SliderFloat3(lua_State* L)
     vec3f[0] = luaL_checknumber(L, 3);
     vec3f[1] = luaL_checknumber(L, 4);
     vec3f[2] = luaL_checknumber(L, 5);
-    int v_min = luaL_optinteger(L, 6, 0);
-    int v_max = luaL_optinteger(L, 7, 0);
+    float v_min = luaL_optnumber(L, 6, 0.0f);
+    float v_max = luaL_optnumber(L, 7, 0.0f);
     const char* format = luaL_optstring(L, 8, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, 0);
 
     bool result = ImGui::SliderFloat3(label, vec3f, v_min, v_max, format, sliderFlag);
 
-    lua_pushinteger(L, vec3f[0]);
-    lua_pushinteger(L, vec3f[1]);
-    lua_pushinteger(L, vec3f[2]);
+    lua_pushnumber(L, vec3f[0]);
+    lua_pushnumber(L, vec3f[1]);
+    lua_pushnumber(L, vec3f[2]);
     lua_pushboolean(L, result);
     return 4;
 }
@@ -3245,17 +3245,17 @@ int SliderFloat4(lua_State* L)
     vec4f[1] = luaL_checknumber(L, 4);
     vec4f[2] = luaL_checknumber(L, 5);
     vec4f[3] = luaL_checknumber(L, 6);
-    int v_min = luaL_optinteger(L, 7, 0);
-    int v_max = luaL_optinteger(L, 8, 0);
+    float v_min = luaL_optnumber(L, 7, 0.0f);
+    float v_max = luaL_optnumber(L, 8, 0.0f);
     const char* format = luaL_optstring(L, 9, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 10, 0);
 
     bool result = ImGui::SliderFloat4(label, vec4f, v_min, v_max, format, sliderFlag);
 
-    lua_pushinteger(L, vec4f[0]);
-    lua_pushinteger(L, vec4f[1]);
-    lua_pushinteger(L, vec4f[2]);
-    lua_pushinteger(L, vec4f[3]);
+    lua_pushnumber(L, vec4f[0]);
+    lua_pushnumber(L, vec4f[1]);
+    lua_pushnumber(L, vec4f[2]);
+    lua_pushnumber(L, vec4f[3]);
     lua_pushboolean(L, result);
     return 5;
 }
@@ -3435,8 +3435,8 @@ int FilledSliderFloat(lua_State* L)
     const char* label = luaL_checkstring(L, 2);
     bool mirror = lua_toboolean(L, 3) > 0;
     float v = luaL_checknumber(L, 4);
-    float v_min = luaL_checknumber(L, 5);
-    float v_max = luaL_checknumber(L, 6);
+    float v_min = luaL_optnumber(L, 5, 0);
+    float v_max = luaL_optnumber(L, 6, 0);
     const char* format = luaL_optstring(L, 7, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 8, 0);
 
@@ -3454,37 +3454,37 @@ int FilledSliderFloat2(lua_State* L)
     float vec2f[2];
     vec2f[0] = luaL_checknumber(L, 4);
     vec2f[1] = luaL_checknumber(L, 5);
-    float v_min = luaL_checknumber(L, 6);
-    float v_max = luaL_checknumber(L, 7);
+    float v_min = luaL_optnumber(L, 6, 0);
+    float v_max = luaL_optnumber(L, 7, 0);
     const char* format = luaL_optstring(L, 8, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, 0);
 
-    bool result = ImGui::FilledSliderFloat(label, mirror, vec2f, v_min, v_max, format, sliderFlag);
+    bool result = ImGui::FilledSliderFloat2(label, mirror, vec2f, v_min, v_max, format, sliderFlag);
 
     lua_pushnumber(L, vec2f[0]);
     lua_pushnumber(L, vec2f[1]);
     lua_pushboolean(L, result);
-    return 2;
+    return 3;
 }
 
 int FilledSliderFloat3(lua_State* L)
 {
     const char* label = luaL_checkstring(L, 2);
     bool mirror = lua_toboolean(L, 3) > 0;
-    float vec4f[3];
-    vec4f[0] = luaL_checknumber(L, 4);
-    vec4f[1] = luaL_checknumber(L, 5);
-    vec4f[2] = luaL_checknumber(L, 6);
-    int v_min = luaL_optinteger(L, 7, 0);
-    int v_max = luaL_optinteger(L, 8, 0);
+    float vec3f[3];
+    vec3f[0] = luaL_checknumber(L, 4);
+    vec3f[1] = luaL_checknumber(L, 5);
+    vec3f[2] = luaL_checknumber(L, 6);
+    float v_min = luaL_optnumber(L, 7, 0);
+    float v_max = luaL_optnumber(L, 8, 0);
     const char* format = luaL_optstring(L, 9, "%.3f");
-    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 10, NULL);
+    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 10, 0);
 
-    bool result = ImGui::FilledSliderFloat3(label, mirror, vec4f, v_min, v_max, format, sliderFlag);
+    bool result = ImGui::FilledSliderFloat3(label, mirror, vec3f, v_min, v_max, format, sliderFlag);
 
-    lua_pushinteger(L, vec4f[0]);
-    lua_pushinteger(L, vec4f[1]);
-    lua_pushinteger(L, vec4f[2]);
+    lua_pushnumber(L, vec3f[0]);
+    lua_pushnumber(L, vec3f[1]);
+    lua_pushnumber(L, vec3f[2]);
     lua_pushboolean(L, result);
     return 4;
 }
@@ -3498,17 +3498,17 @@ int FilledSliderFloat4(lua_State* L)
     vec4f[1] = luaL_checknumber(L, 5);
     vec4f[2] = luaL_checknumber(L, 6);
     vec4f[3] = luaL_checknumber(L, 7);
-    int v_min = luaL_optinteger(L, 8, 0);
-    int v_max = luaL_optinteger(L, 9, 0);
+    float v_min = luaL_optnumber(L, 8, 0);
+    float v_max = luaL_optnumber(L, 9, 0);
     const char* format = luaL_optstring(L, 10, "%.3f");
-    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 11, NULL);
+    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 11, 0);
 
-    bool result = ImGui::FilledSliderFloat3(label, mirror, vec4f, v_min, v_max, format, sliderFlag);
+    bool result = ImGui::FilledSliderFloat4(label, mirror, vec4f, v_min, v_max, format, sliderFlag);
 
-    lua_pushinteger(L, vec4f[0]);
-    lua_pushinteger(L, vec4f[1]);
-    lua_pushinteger(L, vec4f[2]);
-    lua_pushinteger(L, vec4f[3]);
+    lua_pushnumber(L, vec4f[0]);
+    lua_pushnumber(L, vec4f[1]);
+    lua_pushnumber(L, vec4f[2]);
+    lua_pushnumber(L, vec4f[3]);
     lua_pushboolean(L, result);
     return 5;
 }
@@ -3521,7 +3521,7 @@ int FilledSliderAngle(lua_State* L)
     float v_degrees_min = luaL_optnumber(L, 5, -360.0f);
     float v_degrees_max = luaL_optnumber(L, 6,  360.0f);
     const char* format = luaL_optstring(L, 7, "%.0f deg");
-    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 8, NULL);
+    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 8, 0);
 
     bool result = ImGui::FilledSliderAngle(label, mirror, &v_rad, v_degrees_min, v_degrees_max, format, sliderFlag);
 
@@ -3538,7 +3538,7 @@ int FilledSliderInt(lua_State* L)
     int v_min = luaL_optinteger(L, 5, 0);
     int v_max = luaL_optinteger(L, 6, 0);
     const char* format = luaL_optstring(L, 7, "%d");
-    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 8, NULL);
+    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 8, 0);
 
     bool result = ImGui::FilledSliderInt(label, mirror, &v, v_min, v_max, format, sliderFlag);
 
@@ -3620,10 +3620,10 @@ int FilledSliderScalar(lua_State* L)
     bool mirror = lua_toboolean(L, 3) > 0;
     ImGuiDataType data_type = luaL_checkinteger(L, 4);
     double value = luaL_checknumber(L, 5);
-    double v_min = luaL_optnumber(L, 6, NULL);
-    double v_max = luaL_optnumber(L, 7, NULL);
-    const char* format = luaL_optstring(L, 8, NULL);
-    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, NULL);
+    double v_min = luaL_optnumber(L, 6, 0);
+    double v_max = luaL_optnumber(L, 7, 0);
+    const char* format = luaL_optstring(L, 8, "%.3f");
+    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, 0);
 
     bool result = ImGui::FilledSliderScalar(label, mirror, data_type, (void *)&value, (void *)&v_min, (void *)&v_max, format, sliderFlag);
 
@@ -3659,7 +3659,7 @@ int VFilledSliderInt(lua_State* L)
     int v_min = luaL_checkinteger(L, 7);
     int v_max = luaL_checkinteger(L, 8);
     const char* format = luaL_optstring(L, 9, "%d");
-    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 10, NULL);
+    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 10, 0);
 
     bool result = ImGui::VFilledSliderInt(label, mirror, size, &v, v_min, v_max, format, sliderFlag);
 
@@ -3675,10 +3675,10 @@ int VFilledSliderScalar(lua_State* L)
     const ImVec2 size = ImVec2(luaL_checknumber(L, 4), luaL_checknumber(L, 5));
     ImGuiDataType data_type = luaL_checkinteger(L, 6);
     double value = luaL_checknumber(L, 7);
-    double v_min = luaL_optnumber(L, 8, NULL);
-    double v_max = luaL_optnumber(L, 9, NULL);
-    const char* format = luaL_optstring(L, 10, NULL);
-    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 11, NULL);
+    double v_min = luaL_optnumber(L, 8, 0);
+    double v_max = luaL_optnumber(L, 9, 0);
+    const char* format = luaL_optstring(L, 10, "%.3f");
+    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 11, 0);
 
     bool result = ImGui::VFilledSliderScalar(label, mirror, size, data_type, (void *)&value, (void *)&v_min, (void *)&v_max, format, sliderFlag);
 

--- a/plugins/imgui/source/Common/imgui_bindings.cpp
+++ b/plugins/imgui/source/Common/imgui_bindings.cpp
@@ -3362,7 +3362,7 @@ int SliderScalar(lua_State* L)
     double value = luaL_checknumber(L, 4);
     double v_min = luaL_checknumber(L, 5);
     double v_max = luaL_checknumber(L, 6);
-    const char* format = luaL_optstring(L, 7, NULL);
+    const char* format = luaL_optstring(L, 7, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 8, 0);
 
     bool result = ImGui::SliderScalar(label, data_type, (void *)&value, (void *)&v_min, (void *)&v_max, format, sliderFlag);
@@ -3412,9 +3412,9 @@ int VSliderScalar(lua_State* L)
     const ImVec2 size = ImVec2(luaL_checknumber(L, 3), luaL_checknumber(L, 4));
     ImGuiDataType data_type = luaL_checkinteger(L, 5);
     double value = luaL_checknumber(L, 6);
-    double v_min = luaL_optnumber(L, 7, NULL);
-    double v_max = luaL_optnumber(L, 8, NULL);
-    const char* format = luaL_optstring(L, 9, NULL);
+    double v_min = luaL_optnumber(L, 7, 0.0f);
+    double v_max = luaL_optnumber(L, 8, 0.0f);
+    const char* format = luaL_optstring(L, 9, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 10, 0);
 
     bool result = ImGui::VSliderScalar(label, size, data_type, (void *)&value, (void *)&v_min, (void *)&v_max, format, sliderFlag);
@@ -3435,8 +3435,8 @@ int FilledSliderFloat(lua_State* L)
     const char* label = luaL_checkstring(L, 2);
     bool mirror = lua_toboolean(L, 3) > 0;
     float v = luaL_checknumber(L, 4);
-    float v_min = luaL_optnumber(L, 5, 0);
-    float v_max = luaL_optnumber(L, 6, 0);
+    float v_min = luaL_optnumber(L, 5, 0.0f);
+    float v_max = luaL_optnumber(L, 6, 0.0f);
     const char* format = luaL_optstring(L, 7, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 8, 0);
 
@@ -3454,8 +3454,8 @@ int FilledSliderFloat2(lua_State* L)
     float vec2f[2];
     vec2f[0] = luaL_checknumber(L, 4);
     vec2f[1] = luaL_checknumber(L, 5);
-    float v_min = luaL_optnumber(L, 6, 0);
-    float v_max = luaL_optnumber(L, 7, 0);
+    float v_min = luaL_optnumber(L, 6, 0.0f);
+    float v_max = luaL_optnumber(L, 7, 0.0f);
     const char* format = luaL_optstring(L, 8, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, 0);
 
@@ -3475,8 +3475,8 @@ int FilledSliderFloat3(lua_State* L)
     vec3f[0] = luaL_checknumber(L, 4);
     vec3f[1] = luaL_checknumber(L, 5);
     vec3f[2] = luaL_checknumber(L, 6);
-    float v_min = luaL_optnumber(L, 7, 0);
-    float v_max = luaL_optnumber(L, 8, 0);
+    float v_min = luaL_optnumber(L, 7, 0.0f);
+    float v_max = luaL_optnumber(L, 8, 0.0f);
     const char* format = luaL_optstring(L, 9, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 10, 0);
 
@@ -3498,8 +3498,8 @@ int FilledSliderFloat4(lua_State* L)
     vec4f[1] = luaL_checknumber(L, 5);
     vec4f[2] = luaL_checknumber(L, 6);
     vec4f[3] = luaL_checknumber(L, 7);
-    float v_min = luaL_optnumber(L, 8, 0);
-    float v_max = luaL_optnumber(L, 9, 0);
+    float v_min = luaL_optnumber(L, 8, 0.0f);
+    float v_max = luaL_optnumber(L, 9, 0.0f);
     const char* format = luaL_optstring(L, 10, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 11, 0);
 
@@ -3620,8 +3620,8 @@ int FilledSliderScalar(lua_State* L)
     bool mirror = lua_toboolean(L, 3) > 0;
     ImGuiDataType data_type = luaL_checkinteger(L, 4);
     double value = luaL_checknumber(L, 5);
-    double v_min = luaL_optnumber(L, 6, 0);
-    double v_max = luaL_optnumber(L, 7, 0);
+    double v_min = luaL_optnumber(L, 6, 0.0f);
+    double v_max = luaL_optnumber(L, 7, 0.0f);
     const char* format = luaL_optstring(L, 8, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, 0);
 
@@ -3675,8 +3675,8 @@ int VFilledSliderScalar(lua_State* L)
     const ImVec2 size = ImVec2(luaL_checknumber(L, 4), luaL_checknumber(L, 5));
     ImGuiDataType data_type = luaL_checkinteger(L, 6);
     double value = luaL_checknumber(L, 7);
-    double v_min = luaL_optnumber(L, 8, 0);
-    double v_max = luaL_optnumber(L, 9, 0);
+    double v_min = luaL_optnumber(L, 8, 0.0f);
+    double v_max = luaL_optnumber(L, 9, 0.0f);
     const char* format = luaL_optstring(L, 10, "%.3f");
     ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 11, 0);
 
@@ -3739,17 +3739,18 @@ int InputTextMultiline(lua_State* L)
 
 int InputTextWithHint(lua_State* L)
 {
-
     const char* label = luaL_checkstring(L, 2);
     const char* text = luaL_checkstring(L, 3);
     const char* hint = luaL_checkstring(L, 4);
-    size_t buf_size = luaL_checkinteger(L, 5);
-    char* buffer = new char[buf_size];
+//    size_t buf_size = luaL_checkinteger(L, 5);
+    int buffer_size = luaL_checkinteger(L, 5);
+	char* buffer = new char[buffer_size];
     sprintf(buffer, "%s", text);
     ImGuiInputTextFlags flags = luaL_optinteger(L, 6, 0);
 
-    bool result = ImGui::InputTextWithHint(label, hint, buffer, buf_size, flags);
-    lua_pushstring(L, &(*buffer));
+    bool result = ImGui::InputTextWithHint(label, hint, buffer, buffer_size, flags);
+
+	lua_pushstring(L, &(*buffer));
     lua_pushboolean(L, result);
     delete[] buffer;
     return 2;


### PR DESCRIPTION
I wanted to "fix" only:
int FilledSliderFloat2(lua_State* L)
{
    const char* label = luaL_checkstring(L, 2);
    bool mirror = lua_toboolean(L, 3) > 0;
    float vec2f[2];
    vec2f[0] = luaL_checknumber(L, 4);
    vec2f[1] = luaL_checknumber(L, 5);
    float v_min = luaL_checknumber(L, 6);
    float v_max = luaL_checknumber(L, 7);
    const char* format = luaL_optstring(L, 8, "%.3f");
    ImGuiSliderFlags sliderFlag = luaL_optinteger(L, 9, 0);

    bool result = ImGui::FilledSliderFloat(label, mirror, vec2f, v_min, v_max, format, sliderFlag);

    lua_pushnumber(L, vec2f[0]);
    lua_pushnumber(L, vec2f[1]);
    lua_pushboolean(L, result);
    return 2;
}

but I found some other "bugs", hopefully I fixed them right?!