### PR TITLE
Examples\Graphics3D\3D-Anim is broken

### DIFF
--- a/Library/3dbase/3DShapes.lua
+++ b/Library/3dbase/3DShapes.lua
@@ -5,6 +5,7 @@ Mesh3D.MODE_BUMP=4
 Mesh3D.MODE_SHADOW=8
 Mesh3D.MODE_ANIMATED=16
 Mesh3D.MODE_INSTANCED=32
+Mesh3D.MODE_COLORED=64
 
 function Mesh3D:init()
 	self.mode=0


### PR DESCRIPTION
With new addition to Library/3dbase/gltf.lua, and Library/3dbase/G3DFormat.lua ( smode=smode|D3.Mesh.MODE_COLORED), the sample code wouldn't work anymore.

A simple fix for is to add in the 3DShapes.lua:
Mesh3D.MODE_COLORED=64

I don't know if other files need to be changed but with this fix, the sample code is working again.