### PR TITLE
[win32] implementing openFileDialog

### DIFF
--- a/android/GiderosAndroidPlayer/app/src/main/java/com/giderosmobile/android/player/GiderosApplication.java
+++ b/android/GiderosAndroidPlayer/app/src/main/java/com/giderosmobile/android/player/GiderosApplication.java
@@ -816,6 +816,7 @@ public class GiderosApplication
 	static int tisInitCapsMode=0;
 	static String tisBuffer="";
 	static int tisToken=-1;
+	static String tisContext="";
 	
 	public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
 		outAttrs.actionLabel = tisActionLabel;
@@ -837,7 +838,7 @@ public class GiderosApplication
 					tisBuffer=e.toString();
 					//Log.v("EBE","TE:"+tisEditable+" SS:"+tisSelStart+" SE:"+tisSelEnd+" BB:"+e.toString());
 					GiderosApplication app = GiderosApplication.getInstance();
-					nativeTextInput(tisBuffer,tisSelStart,tisSelEnd);
+					nativeTextInput(tisBuffer,tisSelStart,tisSelEnd,tisContext);
 					if (tisToken!=-1) {
 						Activity activity = WeakActivityHolder.get();
 				    	InputMethodManager imm = (InputMethodManager)
@@ -910,7 +911,7 @@ public class GiderosApplication
 		return b;
 	}	 
 	
-	static public boolean setTextInput(final int type,final String buffer,final int selStart,final int selEnd,final String label,final String actionLabel,final String hintText)
+	static public boolean setTextInput(final int type,final String buffer,final int selStart,final int selEnd,final String label,final String actionLabel,final String hintText,final String context)
 	{
 		final Activity activity = WeakActivityHolder.get();
 		activity.runOnUiThread(new Runnable() {
@@ -923,6 +924,7 @@ public class GiderosApplication
 				tisActionLabel=actionLabel;
 				tisHint=hintText;
 				tisInitCapsMode=((type&0x0F)==1)?(type&0x7000):0;
+				tisContext=context;
 				int bl=tisBuffer.length();
 				Log.v("EBE","STI:"+tisType+" SS:"+tisSelStart+" SE:"+tisSelEnd+" BL:"+bl+" BB:"+buffer+" TE:"+tisEditable);
 				if (tisSelStart>bl) tisSelStart=bl;
@@ -1527,7 +1529,7 @@ public class GiderosApplication
 	static private native boolean nativeKeyDown(int keyCode, int repeatCount);
 	static private native boolean nativeKeyUp(int keyCode, int repeatCount);
 	static private native void nativeKeyChar(String keyChar);
-	static private native void nativeTextInput(String buffer,int selStart,int selEnd);
+	static private native void nativeTextInput(String buffer,int selStart,int selEnd, String context);
 	static private native void nativeOpenALSetup(int sampleRate);
 	static private native void nativeCreate(boolean player,Activity activity);
 	static private native void nativeSetDirectories(String externalDir, String internalDir, String cacheDir);

--- a/android/lib/jni/gideros.cpp
+++ b/android/lib/jni/gideros.cpp
@@ -243,7 +243,7 @@ public:
 	bool keyDown(int keyCode, int repeatCount);
 	bool keyUp(int keyCode, int repeatCount);
 	void keyChar(const char *keyChar);
-	void textInput(const char *text,int ss,int se);
+	void textInput(const char *text,int ss,int se,const char *context);
 
 	void pause();
 	void resume();
@@ -1576,11 +1576,12 @@ void ApplicationManager::keyChar(const char *str)
 	ginputp_keyChar(str);
 }
 
-void ApplicationManager::textInput(const char *text,int ss,int se)
+void ApplicationManager::textInput(const char *text,int ss,int se, const char *context)
 {
-    gapplication_TextInputEvent *event = (gapplication_TextInputEvent*)gevent_CreateEventStruct1(
+    gapplication_TextInputEvent *event = (gapplication_TextInputEvent*)gevent_CreateEventStruct2(
                                            sizeof(gapplication_TextInputEvent),
-                                        offsetof(gapplication_TextInputEvent, text), text);
+                                        offsetof(gapplication_TextInputEvent, text), text,
+										offsetof(gapplication_TextInputEvent, context), context);
     event->selStart=ss;
     event->selEnd=se;
 
@@ -1895,7 +1896,7 @@ void Java_com_giderosmobile_android_player_GiderosApplication_nativeKeyChar(JNIE
 	env->ReleaseStringUTFChars(keyChar, sBytes);
 }
 
-void Java_com_giderosmobile_android_player_GiderosApplication_nativeTextInput(JNIEnv* env, jclass cls, jstring text,jint ss,jint se)
+void Java_com_giderosmobile_android_player_GiderosApplication_nativeTextInput(JNIEnv* env, jclass cls, jstring text,jint ss,jint se,jstring context)
 {
 	const char* sBytes = env->GetStringUTFChars(text, NULL);
 	if (ss>0) {
@@ -1920,8 +1921,10 @@ void Java_com_giderosmobile_android_player_GiderosApplication_nativeTextInput(JN
 		while (((*r)&0xC0)==0x80) r++;
 		se=r-sBytes;
 	}
+	const char* sContext = env->GetStringUTFChars(context, NULL);
 
-	s_applicationManager->textInput(sBytes,ss,se);
+	s_applicationManager->textInput(sBytes,ss,se,sContext);
+	env->ReleaseStringUTFChars(text, sContext);
 	env->ReleaseStringUTFChars(text, sBytes);
 }
 

--- a/emscripten/main.cpp
+++ b/emscripten/main.cpp
@@ -283,12 +283,15 @@ EM_BOOL mouse_callback(int eventType, const EmscriptenMouseEvent *e, void *userD
 	 if (e->altKey) m|=GINPUT_ALT_MODIFIER;
 	 if (e->metaKey) m|=GINPUT_META_MODIFIER;
 
-	 if (eventType == EMSCRIPTEN_EVENT_MOUSEDOWN)
+	 if (eventType == EMSCRIPTEN_EVENT_MOUSEDOWN) {
+		 //EM_ASM( document.getElementById("canvas").setCapture(true); );
 		 ginputp_mouseDown(x,y,bs,m);
+	 }
 	 else if (eventType == EMSCRIPTEN_EVENT_MOUSEUP)
 	 {
 		 checkEventTriggers();
 		 ginputp_mouseUp(x,y,bs,m);
+		 //if (!b) EM_ASM( document.getElementById("canvas").setCapture(false); );
 	 }
 	 else if (eventType == EMSCRIPTEN_EVENT_MOUSEMOVE)
 	 {

--- a/emscripten/platform-js.cpp
+++ b/emscripten/platform-js.cpp
@@ -32,7 +32,7 @@ bool setKeyboardVisibility(bool visible){
 	return false;
 }
 
-bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText)
+bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText, const char *context)
 {
 	return false;
 }

--- a/ios/iosplayer/iosplayer/giderosapi.mm
+++ b/ios/iosplayer/iosplayer/giderosapi.mm
@@ -1723,7 +1723,7 @@ bool setKeyboardVisibility(bool visible){
     return false;
 }
 
-bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText)
+bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText, const char *context)
 {
 	return false;
 }

--- a/libgid/include/gapplication.h
+++ b/libgid/include/gapplication.h
@@ -12,6 +12,7 @@ typedef struct gapplication_OpenUrlEvent
 typedef struct gapplication_TextInputEvent
 {
     const char *text;
+    const char *context;
     int selStart;
     int selEnd;
 } gapplication_TextInputEvent;

--- a/libgid/include/platform.h
+++ b/libgid/include/platform.h
@@ -185,7 +185,7 @@ std::string getLanguage();
 void setKeepAwake(bool awake);
 bool setKeyboardVisibility(bool visible);
 int getKeyboardModifiers();
-bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText);
+bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText, const char *context);
 typedef struct gapplication_ClipboardResponseCb
 {
 	bool result;

--- a/libgid/src/android/platform-android.cpp
+++ b/libgid/src/android/platform-android.cpp
@@ -74,7 +74,7 @@ bool setKeyboardVisibility(bool visible)
 }
 
 
-bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText)
+bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText, const char *context)
 {
 	JNIEnv *env = g_getJNIEnv();
 
@@ -83,6 +83,7 @@ bool setTextInput(int type,const char *buffer,int selstart,int selend,const char
 	jstring jlabel = env->NewStringUTF(label);
 	jstring jaction = env->NewStringUTF(actionLabel);
 	jstring jhint = env->NewStringUTF(hintText);
+	jstring jcontext = env->NewStringUTF(context);
 
 	if (selstart>0) {
 		int n=0;
@@ -97,12 +98,13 @@ bool setTextInput(int type,const char *buffer,int selstart,int selend,const char
 		selend=n;
 	}
 
-	jmethodID setKeepAwakeID = env->GetStaticMethodID(localRefCls, "setTextInput", "(ILjava/lang/String;IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z");
-	jboolean ret=env->CallStaticBooleanMethod(localRefCls, setKeepAwakeID, (jint)type,jbuf,(jint)selstart,(jint)selend,jlabel,jaction,jhint);
+	jmethodID setKeepAwakeID = env->GetStaticMethodID(localRefCls, "setTextInput", "(ILjava/lang/String;IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z");
+	jboolean ret=env->CallStaticBooleanMethod(localRefCls, setKeepAwakeID, (jint)type,jbuf,(jint)selstart,(jint)selend,jlabel,jaction,jhint,jcontext);
 	env->DeleteLocalRef(jbuf);
 	env->DeleteLocalRef(jlabel);
 	env->DeleteLocalRef(jaction);
 	env->DeleteLocalRef(jhint);
+	env->DeleteLocalRef(jcontext);
 	env->DeleteLocalRef(localRefCls);
 	return ret;
 }

--- a/libgid/src/pi/platform-pi.cpp
+++ b/libgid/src/pi/platform-pi.cpp
@@ -64,7 +64,7 @@ bool setKeyboardVisibility(bool visible){
 	return false;
 }
 
-bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText)
+bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText, const char *context)
 {
 	return false;
 }

--- a/libgid/src/qt/platform-qt.cpp
+++ b/libgid/src/qt/platform-qt.cpp
@@ -78,7 +78,7 @@ bool setKeyboardVisibility(bool visible){
 	return false;
 }
 
-bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText)
+bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText, const char *context)
 {
 	return false;
 }

--- a/libgid/src/win32/platform-win32.cpp
+++ b/libgid/src/win32/platform-win32.cpp
@@ -213,7 +213,7 @@ bool setKeyboardVisibility(bool visible){
 	return false;
 }
 
-bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText)
+bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText, const char *context)
 {
 	return false;
 }

--- a/libgid/src/winrt/platform-winrt.cpp
+++ b/libgid/src/winrt/platform-winrt.cpp
@@ -191,7 +191,7 @@ bool setKeyboardVisibility(bool visible) {
 }
 #endif
 
-bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText)
+bool setTextInput(int type,const char *buffer,int selstart,int selend,const char *label,const char *actionLabel, const char *hintText, const char *context)
 {
 	return false;
 }

--- a/libgideros/event.h
+++ b/libgideros/event.h
@@ -117,15 +117,17 @@ class GIDEROS_API TextInputEvent : public Event
 {
 public:
 	typedef EventType<TextInputEvent> Type;
-	TextInputEvent(const Type& type,const char *text,int selStart,int selEnd) : Event(type.type()),	text_(text),selStart_(selStart),selEnd_(selEnd) {	}
+	TextInputEvent(const Type& type,const char *text,const char *context, int selStart,int selEnd) : Event(type.type()),	text_(text),context_(context),selStart_(selStart),selEnd_(selEnd) {	}
 	virtual ~TextInputEvent() {}
 	const char *text() { return text_.c_str(); }
+	const char *context() { return context_.c_str(); }
 	int selStart() { return selStart_; }
 	int selEnd() { return selEnd_; }
 	virtual void apply(EventVisitor* v);
 	static Type TEXT_INPUT;
 private:
 	std::string text_;
+	std::string context_;
 	int selStart_;
 	int selEnd_;
 };

--- a/luabinding/applicationbinder.cpp
+++ b/luabinding/applicationbinder.cpp
@@ -485,7 +485,8 @@ int ApplicationBinder::setTextInput(lua_State* L)
 			luaL_optinteger(L,5,luaL_optinteger(L,4,0)),
 			luaL_optstring(L,6,""),
 			luaL_optstring(L,7,""),
-			luaL_optstring(L,8,"")
+			luaL_optstring(L,8,""),
+			luaL_optstring(L,9,"")
 			));
 
 	return 1;

--- a/luabinding/eventdispatcherbinder.cpp
+++ b/luabinding/eventdispatcherbinder.cpp
@@ -729,6 +729,9 @@ public:
             lua_pushstring(L, v->text());
             lua_setfield(L, -2, "text");
 
+            lua_pushstring(L, v->context());
+            lua_setfield(L, -2, "context");
+
             lua_pushinteger(L, v->selStart());
             lua_setfield(L, -2, "selectionStart");
 

--- a/luabinding/luaapplication.cpp
+++ b/luabinding/luaapplication.cpp
@@ -1020,7 +1020,7 @@ void LuaApplication::callback(int type, void *event)
     else if (type == GAPPLICATION_TEXT_INPUT_EVENT)
     {
         gapplication_TextInputEvent *event2 = (gapplication_TextInputEvent*)event;
-        TextInputEvent eventg(TextInputEvent::TEXT_INPUT,event2->text,event2->selStart,event2->selEnd);
+        TextInputEvent eventg(TextInputEvent::TEXT_INPUT,event2->text,event2->context,event2->selStart,event2->selEnd);
         application_->broadcastEvent(&eventg);
     }
     else if (type == GAPPLICATION_MEMORY_LOW_EVENT)


### PR DESCRIPTION
I almost get win32 openFileDialog working :-(
- set title **OK**
- set start directory **OK**
- filter extensions **NOT OK** :-(

You use the usual `application:get("openFileDialog", "Title|startdir|Text (*.txt);; Image (*.png)")`. A sample code:
--	local picdir = application:get("directory", "pictures") -- result C:\Users\xxx\Pictures
	local picdir = "c:\\tmp" -- "C:/tmp/" -> old format is not working!
	local path = application:get("openFileDialog", "My Title|"..picdir.."|Text (*.txt);; Image (*.png)")

Compiled and tested with the latest hgy29 commit on my windows 10 machine. I tried following coding style as much as I could. Hope this helps?
[platform-win32.zip](https://github.com/gideros/gideros/files/9884948/platform-win32.zip)
