### PR TITLE
Plugins Require Window size too small

### DIFF
--- a/ui/plugineditor.ui
+++ b/ui/plugineditor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>750</width>
+    <width>884</width>
     <height>470</height>
    </rect>
   </property>


### PR DESCRIPTION
When you add the Require plugin and go to its properties, when you hover with the mouse an option checkbox, the horizontal scroll bar jumps to the right and option text becomes unreadable.

So I propose to increase the window width quite a bit.

Thank you :-)