### PR TITLE
missing alpha value for fbx (json) models

### DIFF
--- a/Library/3dbase/3DGdxLoader.lua
+++ b/Library/3dbase/3DGdxLoader.lua
@@ -146,7 +146,8 @@ function loadGdx(file,imtls)
 	-- materials (texture id, tex path, color, ...)
 	for _,mat in ipairs(gdx.materials or {}) do
 		local md=mtls[mat.id] or {}
-		md.kd=mat.diffuse
+		md.kd=mat.diffuse -- json node "materials - diffuse"
+		md.kd[4]=mat.opacity -- json node "materials - opacity", fix missing alpha value for setColorTransform
 		md.modelpath = mtls.modelpath
 --		print("md model path", md.modelpath)
 		for _, tex in ipairs(mat.textures or {}) do -- XXX


### PR DESCRIPTION
In G3DFormat.lua we use setColorTransform() based on mtl.kd:
	-- COLOR
	if mtl.kd then m:setColorTransform(mtl.kd[1], mtl.kd[2], mtl.kd[3], mtl.kd[4]) end

The problem is fbx (json) was missing its alpha value mtl.kd[4] which would crash the app.