### PR TITLE
sticky modifier keys

### DIFF
--- a/libgid/src/win32/platform-win32.cpp
+++ b/libgid/src/win32/platform-win32.cpp
@@ -230,9 +230,9 @@ int getClipboard(std::string &data,std::string &mimeType, int luaFunc)
 int getKeyboardModifiers()
 {
 	int m=0;
-	if (GetAsyncKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER; // new 20221114 XXX
-	if (GetAsyncKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER; // new 20221114 XXX
-	if (GetAsyncKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER; // new 20221114 XXX
+	if (GetAsyncKeyState(VK_CONTROL) & 0x8000) m|=GINPUT_CTRL_MODIFIER;
+	if (GetAsyncKeyState(VK_SHIFT) & 0x8000) m|=GINPUT_SHIFT_MODIFIER;
+	if (GetAsyncKeyState(VK_MENU) & 0x8000) m|=GINPUT_ALT_MODIFIER;
 	return m;
 }
 

--- a/win32_example/win32.cpp
+++ b/win32_example/win32.cpp
@@ -768,22 +768,22 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
     return 0;
   }
   else if ((iMsg==WM_KEYDOWN)||(iMsg==WM_SYSKEYDOWN)) {
-	int m=0;
-	if (GetAsyncKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
-	if (GetAsyncKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
-	if (GetAsyncKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
-	if (!(lParam&0x40000000)) // Don't send repeated keys
-		ginputp_keyDown(wParam,m);
-	if ((iMsg==WM_KEYDOWN)||(wParam==VK_F10))
-		return 0;
+	  int m=0;
+	  if (GetKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
+	  if (GetKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
+	  if (GetKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
+	 if (!(lParam&0x40000000)) //Don't send repeated keys
+		 ginputp_keyDown(wParam,m);
+    if ((iMsg==WM_KEYDOWN)||(wParam==VK_F10))
+    	return 0;
   }
   else if ((iMsg==WM_KEYUP)||(iMsg==WM_SYSKEYUP)) {
-	int m=0;
-	if (GetAsyncKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
-	if (GetAsyncKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
-	if (GetAsyncKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
-	ginputp_keyUp(wParam,m);
-	return 0;
+	  int m=0;
+	  if (GetKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
+	  if (GetKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
+	  if (GetKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
+    ginputp_keyUp(wParam,m);
+    return 0;
   }
   else if (iMsg==WM_CHAR){
 	char sc[4];

--- a/win32_example/win32.cpp
+++ b/win32_example/win32.cpp
@@ -768,22 +768,22 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
     return 0;
   }
   else if ((iMsg==WM_KEYDOWN)||(iMsg==WM_SYSKEYDOWN)) {
-	  int m=0;
-	  if (GetKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
-	  if (GetKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
-	  if (GetKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
-	 if (!(lParam&0x40000000)) //Don't send repeated keys
-		 ginputp_keyDown(wParam,m);
-    if ((iMsg==WM_KEYDOWN)||(wParam==VK_F10))
-    	return 0;
+	int m=0;
+	if (GetAsyncKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
+	if (GetAsyncKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
+	if (GetAsyncKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
+	if (!(lParam&0x40000000)) // Don't send repeated keys
+		ginputp_keyDown(wParam,m);
+	if ((iMsg==WM_KEYDOWN)||(wParam==VK_F10))
+		return 0;
   }
   else if ((iMsg==WM_KEYUP)||(iMsg==WM_SYSKEYUP)) {
-	  int m=0;
-	  if (GetKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
-	  if (GetKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
-	  if (GetKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
-    ginputp_keyUp(wParam,m);
-    return 0;
+	int m=0;
+	if (GetAsyncKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
+	if (GetAsyncKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
+	if (GetAsyncKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
+	ginputp_keyUp(wParam,m);
+	return 0;
   }
   else if (iMsg==WM_CHAR){
 	char sc[4];

--- a/win32_example/win32.cpp
+++ b/win32_example/win32.cpp
@@ -768,22 +768,22 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
     return 0;
   }
   else if ((iMsg==WM_KEYDOWN)||(iMsg==WM_SYSKEYDOWN)) {
-	  int m=0;
-	  if (GetKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
-	  if (GetKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
-	  if (GetKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
-	 if (!(lParam&0x40000000)) //Don't send repeated keys
-		 ginputp_keyDown(wParam,m);
-    if ((iMsg==WM_KEYDOWN)||(wParam==VK_F10))
-    	return 0;
+		int m=0;
+		if (GetKeyState(VK_CONTROL) & 0x8000) m|=GINPUT_CTRL_MODIFIER;
+		if (GetKeyState(VK_SHIFT) & 0x8000) m|=GINPUT_SHIFT_MODIFIER;
+		if (GetKeyState(VK_MENU) & 0x8000) m|=GINPUT_ALT_MODIFIER;
+		if (!(lParam & 0x40000000)) // don't send repeated keys
+			ginputp_keyDown(wParam,m);
+		if ((iMsg==WM_KEYDOWN)||(wParam==VK_F10))
+			return 0;
   }
   else if ((iMsg==WM_KEYUP)||(iMsg==WM_SYSKEYUP)) {
-	  int m=0;
-	  if (GetKeyState(VK_CONTROL)) m|=GINPUT_CTRL_MODIFIER;
-	  if (GetKeyState(VK_SHIFT)) m|=GINPUT_SHIFT_MODIFIER;
-	  if (GetKeyState(VK_MENU)) m|=GINPUT_ALT_MODIFIER;
-    ginputp_keyUp(wParam,m);
-    return 0;
+		int m=0;
+		if (GetKeyState(VK_CONTROL) & 0x8000) m|=GINPUT_CTRL_MODIFIER;
+		if (GetKeyState(VK_SHIFT) & 0x8000) m|=GINPUT_SHIFT_MODIFIER;
+		if (GetKeyState(VK_MENU) & 0x8000) m|=GINPUT_ALT_MODIFIER;
+		ginputp_keyUp(wParam,m);
+		return 0;
   }
   else if (iMsg==WM_CHAR){
 	char sc[4];
@@ -806,7 +806,7 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
 	  }
 	 }
 	 *(obuf++)=0;
-	 if (!(lParam&0x40000000)) //Don't send repeated keys
+	 if (!(lParam&0x40000000)) // don't send repeated keys XXX
 		 ginputp_keyChar(sc);
     return 0;
   }


### PR DESCRIPTION
My issue was in win32 when a key modifier was being pressed (SHIFT, ALT, CTRL) it wouldn't get released when no longer pressed (it was like stuck in the pressed state). To cancel the pressed state one had to press the modifier key again!

I changed according to your recommandation and now using _if (GetKeyState(VK_xxx) & 0x8000)_

I also added _& 0x8000_ to **int getKeyboardModifiers()** but I kept the GetAsyncKeyState otherwise the modifiers wouldn't work with the mouse.

I tested and this looks good to me with many shortcut keys (NUMPAD, F1->F12, PAGE_UP, PAGE_DOWN, ...)

Thank you 🛩️ 