### PR TITLE
uispinner.lua

### DIFF
--- a/Library/ui/uispinner.lua
+++ b/Library/ui/uispinner.lua
@@ -66,7 +66,7 @@ function UI.Spinner:setValue(val)
 	if self.range.Step then
 		val=((val+self.range.Step*.5)//self.range.Step)*self.range.Step
 		if val>self.range.Max then val=self.range.Max
-		elseif val<self.range.Min then val=self.range.Min
+		elseif val<=self.range.Min then val=self.range.Min
 		end
 	end
 	if self.range.Check then


### PR DESCRIPTION
When we click the left arrow to decrease the value it would go negative, printing both 0 then -0.

Adding the = sign seems to fix it:
	elseif val<=self.range.Min then val=self.range.Min -- XXX